### PR TITLE
pointer visible on fullscreen slide

### DIFF
--- a/record-and-playback/presentation/playback/presentation/2.0/playback.html
+++ b/record-and-playback/presentation/playback/presentation/2.0/playback.html
@@ -37,7 +37,6 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
     <img id="load-img" class="loading-img" src="logo.png">
     <p id="load-msg">Loading</p>
   </div>
-  <div class="circle" id="cursor"></div>
   <div id="playback-content" class="off-canvas-wrap" data-offcanvas>
 
     <div class="inner-wrap">
@@ -64,6 +63,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
           <div id="presentation-area" role="region" aria-label="Presentation" data-swap>
             <div id="slide" role="img" aria-labelledby="slideText"></div>
             <div id="slideText" class="show-for-sr" aria-live="polite"></div>
+            <div class="circle" id="cursor"></div>
           </div>
 
           <div id="copyright"></div>


### PR DESCRIPTION
Make the pointer visible even when the slide is full-screened.