### PR TITLE
Optional synchronised update of annotations and pen smoothing

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/WhiteboardModel.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/WhiteboardModel.scala
@@ -117,7 +117,7 @@ class WhiteboardModel extends SystemConfiguration {
 
     //not empty and head id equals annotation id
     //println("!usersAnnotations.isEmpty: " + (!usersAnnotations.isEmpty) + ", usersAnnotations.head.id == annotation.id: " + (usersAnnotations.head.id == annotation.id));
-    
+
     var dimensions: List[Int] = List[Int]()
     annotation.annotationInfo.get("dimensions").foreach(d => {
       d match {

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/WhiteboardModel.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/WhiteboardModel.scala
@@ -93,8 +93,7 @@ class WhiteboardModel extends SystemConfiguration {
         }
       }) //newPoints = a.asInstanceOf[ArrayList[Float]])
       val updatedAnnotationData = annotation.annotationInfo + ("points" -> (oldPoints ::: newPoints))
-      val updatedAnnotation = annotation.copy(position = oldAnnotation.position, annotationInfo = updatedAnnotationData)
-
+      
       val newPosition = wb.annotationCount
       val updatedAnnotation = annotation.copy(position = newPosition, annotationInfo = updatedAnnotationData)
       

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/whiteboard/ModifyWBModePubMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/whiteboard/ModifyWBModePubMsgHdlr.scala
@@ -21,7 +21,7 @@ trait ModifyWBModePubMsgHdlr extends RightsManagementTrait {
       bus.outGW.send(msgEvent)
     }
 
-    if (filterWhiteboardMessage(msg.body.meetingId, msg.header.userId, liveMeeting) && permissionFailed(PermissionCheck.GUEST_LEVEL, PermissionCheck.PRESENTER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
+    if (filterWhiteboardMessage(msg.body.meetingId, msg.header.userId, liveMeeting) && permissionFailed(PermissionCheck.MOD_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
       val meetingId = liveMeeting.props.meetingProp.intId
       val reason = "No permission to modify the whiteboard style."
       PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, bus.outGW, liveMeeting)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/whiteboard/ModifyWBModePubMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/whiteboard/ModifyWBModePubMsgHdlr.scala
@@ -1,0 +1,34 @@
+package org.bigbluebutton.core.apps.whiteboard
+
+import org.bigbluebutton.core.running.LiveMeeting
+import org.bigbluebutton.common2.msgs._
+import org.bigbluebutton.core.bus.MessageBus
+import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
+
+trait ModifyWBModePubMsgHdlr extends RightsManagementTrait {
+  this: WhiteboardApp2x =>
+
+  def handle(msg: ModifyWBModePubMsg, liveMeeting: LiveMeeting, bus: MessageBus): Unit = {
+
+    def broadcastEvent(msg: ModifyWBModePubMsg): Unit = {
+      val routing = Routing.addMsgToHtml5InstanceIdRouting(liveMeeting.props.meetingProp.intId, liveMeeting.props.systemProps.html5InstanceId.toString)
+      val envelope = BbbCoreEnvelope(ModifyWBModeEvtMsg.NAME, routing)
+      val header = BbbClientMsgHeader(ModifyWBModeEvtMsg.NAME, liveMeeting.props.meetingProp.intId, msg.header.userId)
+
+      val body = ModifyWBModeEvtMsgBody(msg.body.whiteboardMode)
+      val event = ModifyWBModeEvtMsg(header, body)
+      val msgEvent = BbbCommonEnvCoreMsg(envelope, event)
+      bus.outGW.send(msgEvent)
+    }
+
+    if (filterWhiteboardMessage(msg.body.meetingId, msg.header.userId, liveMeeting) && permissionFailed(PermissionCheck.GUEST_LEVEL, PermissionCheck.PRESENTER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
+      val meetingId = liveMeeting.props.meetingProp.intId
+      val reason = "No permission to modify the whiteboard style."
+      PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, bus.outGW, liveMeeting)
+    } else {
+      println("ModifyWBModePubMsgHdlr " + msg.body.whiteboardMode)
+      modifyWBMode(msg.body.meetingId, msg.body.whiteboardMode, liveMeeting)
+      broadcastEvent(msg)
+    }
+  }
+}

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/whiteboard/ModifyWBModePubMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/whiteboard/ModifyWBModePubMsgHdlr.scala
@@ -26,7 +26,6 @@ trait ModifyWBModePubMsgHdlr extends RightsManagementTrait {
       val reason = "No permission to modify the whiteboard style."
       PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, bus.outGW, liveMeeting)
     } else {
-      println("ModifyWBModePubMsgHdlr " + msg.body.whiteboardMode)
       modifyWBMode(msg.body.meetingId, msg.body.whiteboardMode, liveMeeting)
       broadcastEvent(msg)
     }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/whiteboard/WhiteboardApp2x.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/whiteboard/WhiteboardApp2x.scala
@@ -21,6 +21,7 @@ class WhiteboardApp2x(implicit val context: ActorContext)
   with ClearWhiteboardPubMsgHdlr
   with UndoWhiteboardPubMsgHdlr
   with ModifyWhiteboardAccessPubMsgHdlr
+  with ModifyWBModePubMsgHdlr
   with SendWhiteboardAnnotationPubMsgHdlr
   with GetWhiteboardAnnotationsReqMsgHdlr {
 
@@ -31,6 +32,7 @@ class WhiteboardApp2x(implicit val context: ActorContext)
     var rtnAnnotation: AnnotationVO = annotation
 
     if (WhiteboardKeyUtil.DRAW_START_STATUS == annotation.status) {
+      //This does not happen anymore since 2.3
       rtnAnnotation = liveMeeting.wbModel.addAnnotation(annotation.wbId, annotation.userId, annotation)
     } else if (WhiteboardKeyUtil.DRAW_UPDATE_STATUS == annotation.status) {
       if (WhiteboardKeyUtil.PENCIL_TYPE == annotation.annotationType) {
@@ -72,6 +74,10 @@ class WhiteboardApp2x(implicit val context: ActorContext)
     liveMeeting.wbModel.modifyWhiteboardAccess(whiteboardId, multiUser)
   }
 
+  def modifyWBMode(meetingId: String, whiteboardMode: Map[String, Boolean], liveMeeting: LiveMeeting) {
+    liveMeeting.wbModel.modifyWBMode(meetingId, whiteboardMode)
+  }
+      
   def filterWhiteboardMessage(whiteboardId: String, userId: String, liveMeeting: LiveMeeting): Boolean = {
     // Need to check if the wb mode change from multi-user to single-user. Give 5sec allowance to
     // allow delayed messages to be handled as clients may have been sending messages while the wb

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/pubsub/senders/ReceivedJsonMsgHandlerActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/pubsub/senders/ReceivedJsonMsgHandlerActor.scala
@@ -220,6 +220,8 @@ class ReceivedJsonMsgHandlerActor(
         routeGenericMsg[SendCursorPositionPubMsg](envelope, jsonNode)
       case ModifyWhiteboardAccessPubMsg.NAME =>
         routeGenericMsg[ModifyWhiteboardAccessPubMsg](envelope, jsonNode)
+      case ModifyWBModePubMsg.NAME =>
+        routeGenericMsg[ModifyWBModePubMsg](envelope, jsonNode)
       case ClearWhiteboardPubMsg.NAME =>
         routeGenericMsg[ClearWhiteboardPubMsg](envelope, jsonNode)
       case UndoWhiteboardPubMsg.NAME =>

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
@@ -424,6 +424,7 @@ class MeetingActor(
       case m: ClearWhiteboardPubMsg          => wbApp.handle(m, liveMeeting, msgBus)
       case m: UndoWhiteboardPubMsg           => wbApp.handle(m, liveMeeting, msgBus)
       case m: ModifyWhiteboardAccessPubMsg   => wbApp.handle(m, liveMeeting, msgBus)
+      case m: ModifyWBModePubMsg             => wbApp.handle(m, liveMeeting, msgBus)
       case m: SendWhiteboardAnnotationPubMsg => wbApp.handle(m, liveMeeting, msgBus)
       case m: GetWhiteboardAnnotationsReqMsg => wbApp.handle(m, liveMeeting, msgBus)
 

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/WhiteboardMsgs.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/WhiteboardMsgs.scala
@@ -20,6 +20,10 @@ object ModifyWhiteboardAccessPubMsg { val NAME = "ModifyWhiteboardAccessPubMsg" 
 case class ModifyWhiteboardAccessPubMsg(header: BbbClientMsgHeader, body: ModifyWhiteboardAccessPubMsgBody) extends StandardMsg
 case class ModifyWhiteboardAccessPubMsgBody(whiteboardId: String, multiUser: Array[String])
 
+object ModifyWBModePubMsg { val NAME = "ModifyWBModePubMsg" }
+case class ModifyWBModePubMsg(header: BbbClientMsgHeader, body: ModifyWBModePubMsgBody) extends StandardMsg
+case class ModifyWBModePubMsgBody(meetingId: String, whiteboardMode: Map[String, Boolean])
+
 object SendCursorPositionPubMsg { val NAME = "SendCursorPositionPubMsg" }
 case class SendCursorPositionPubMsg(header: BbbClientMsgHeader, body: SendCursorPositionPubMsgBody) extends StandardMsg
 case class SendCursorPositionPubMsgBody(whiteboardId: String, xPercent: Double, yPercent: Double)
@@ -53,6 +57,10 @@ case class GetWhiteboardAnnotationsRespMsgBody(whiteboardId: String, annotations
 object ModifyWhiteboardAccessEvtMsg { val NAME = "ModifyWhiteboardAccessEvtMsg" }
 case class ModifyWhiteboardAccessEvtMsg(header: BbbClientMsgHeader, body: ModifyWhiteboardAccessEvtMsgBody) extends BbbCoreMsg
 case class ModifyWhiteboardAccessEvtMsgBody(whiteboardId: String, multiUser: Array[String])
+
+object ModifyWBModeEvtMsg { val NAME = "ModifyWBModeEvtMsg" }
+case class ModifyWBModeEvtMsg(header: BbbClientMsgHeader, body: ModifyWBModeEvtMsgBody) extends BbbCoreMsg
+case class ModifyWBModeEvtMsgBody(whiteboardMode: Map[String, Boolean])
 
 object SendCursorPositionEvtMsg { val NAME = "SendCursorPositionEvtMsg" }
 case class SendCursorPositionEvtMsg(header: BbbClientMsgHeader, body: SendCursorPositionEvtMsgBody) extends BbbCoreMsg

--- a/bigbluebutton-html5/imports/api/annotations/addAnnotation.js
+++ b/bigbluebutton-html5/imports/api/annotations/addAnnotation.js
@@ -105,12 +105,14 @@ function handlePencilUpdate(meetingId, whiteboardId, userId, annotation) {
       };
       break;
     case DRAW_UPDATE:
+      //setting annotationType seems necessary when a user joins during drawing
       baseModifier = {
         $push: {
           'annotationInfo.points': { $each: annotationInfo.points },
         },
         $set: {
           status,
+          annotationType,
         },
         $inc: { version: 1 },
       };

--- a/bigbluebutton-html5/imports/api/annotations/server/methods/sendAnnotationHelper.js
+++ b/bigbluebutton-html5/imports/api/annotations/server/methods/sendAnnotationHelper.js
@@ -2,14 +2,11 @@ import RedisPubSub from '/imports/startup/server/redis';
 import { Meteor } from 'meteor/meteor';
 import { check } from 'meteor/check';
 import Logger from '/imports/startup/server/logger';
-import Meetings from '/imports/api/meetings';
 
 export default function sendAnnotationHelper(annotation, meetingId, requesterUserId) {
   const REDIS_CONFIG = Meteor.settings.private.redis;
   const CHANNEL = REDIS_CONFIG.channels.toAkkaApps;
   const EVENT_NAME = 'SendWhiteboardAnnotationPubMsg';
-
-  const whiteboardMode = Meetings.findOne({ meetingId }, { fields: {synchronizeWBUpdate: 1} } )
   
   try {
     const whiteboardId = annotation.wbId;
@@ -61,7 +58,7 @@ export default function sendAnnotationHelper(annotation, meetingId, requesterUse
         position: Number,
       });
     }
-    
+
     const payload = {
       annotation,
       drawEndOnly: true,

--- a/bigbluebutton-html5/imports/api/annotations/server/methods/sendAnnotationHelper.js
+++ b/bigbluebutton-html5/imports/api/annotations/server/methods/sendAnnotationHelper.js
@@ -59,17 +59,12 @@ export default function sendAnnotationHelper(annotation, meetingId, requesterUse
         wbId: String,
         userId: String,
         position: Number,
-        pencilPoint: Match.Maybe(Boolean),
       });
     }
-
-    //drawEndOnly is true when a point is drawn by pencil tool
-    const drawEndOnly = whiteboardMode.synchronizeWBUpdate ? (annotation.pencilPoint == undefined ? true : annotation.pencilPoint) : true;
-    delete annotation.pencilPoint; //unnecessary for akka-apps
     
     const payload = {
       annotation,
-      drawEndOnly,
+      drawEndOnly: true,
     };
 
     return RedisPubSub.publishUserMessage(CHANNEL, EVENT_NAME, meetingId, requesterUserId, payload);

--- a/bigbluebutton-html5/imports/api/annotations/server/methods/sendAnnotationHelper.js
+++ b/bigbluebutton-html5/imports/api/annotations/server/methods/sendAnnotationHelper.js
@@ -7,7 +7,7 @@ export default function sendAnnotationHelper(annotation, meetingId, requesterUse
   const REDIS_CONFIG = Meteor.settings.private.redis;
   const CHANNEL = REDIS_CONFIG.channels.toAkkaApps;
   const EVENT_NAME = 'SendWhiteboardAnnotationPubMsg';
-  
+
   try {
     const whiteboardId = annotation.wbId;
 

--- a/bigbluebutton-html5/imports/api/annotations/server/methods/sendAnnotationHelper.js
+++ b/bigbluebutton-html5/imports/api/annotations/server/methods/sendAnnotationHelper.js
@@ -63,8 +63,11 @@ export default function sendAnnotationHelper(annotation, meetingId, requesterUse
       });
     }
 
-    //drawEndOnly is true when a point is drawn by pencil tool
-    const drawEndOnly = whiteboardMode.synchronizeWBUpdate ? (annotation.pencilPoint == undefined ? true : annotation.pencilPoint) : true;
+    //drawEndOnly is true when a point is drawn by pencil tool even in the synchronized mode. PencilPoint can be undefined.
+    let drawEndOnly = true;
+    if (whiteboardMode.synchronizeWBUpdate && annotation.pencilPoint == false) {
+      drawEndOnly = false;
+    }
     delete annotation.pencilPoint; //unnecessary for akka-apps
     
     const payload = {

--- a/bigbluebutton-html5/imports/api/annotations/server/methods/sendAnnotationHelper.js
+++ b/bigbluebutton-html5/imports/api/annotations/server/methods/sendAnnotationHelper.js
@@ -63,11 +63,8 @@ export default function sendAnnotationHelper(annotation, meetingId, requesterUse
       });
     }
 
-    //drawEndOnly is true when a point is drawn by pencil tool even in the synchronized mode. PencilPoint can be undefined.
-    let drawEndOnly = true;
-    if (whiteboardMode.synchronizeWBUpdate && annotation.pencilPoint == false) {
-      drawEndOnly = false;
-    }
+    //drawEndOnly is true when a point is drawn by pencil tool
+    const drawEndOnly = whiteboardMode.synchronizeWBUpdate ? (annotation.pencilPoint == undefined ? true : annotation.pencilPoint) : true;
     delete annotation.pencilPoint; //unnecessary for akka-apps
     
     const payload = {

--- a/bigbluebutton-html5/imports/api/meetings/server/eventHandlers.js
+++ b/bigbluebutton-html5/imports/api/meetings/server/eventHandlers.js
@@ -13,6 +13,7 @@ import handleTimeRemainingUpdate from './handlers/timeRemainingUpdate';
 import handleChangeWebcamOnlyModerator from './handlers/webcamOnlyModerator';
 import handleSelectRandomViewer from './handlers/selectRandomViewer';
 import handleBroadcastLayout from './handlers/broadcastLayout';
+import handleModifyWBMode from './handlers/modifyWBMode';
 
 RedisPubSub.on('MeetingCreatedEvtMsg', handleMeetingCreation);
 RedisPubSub.on('SyncGetMeetingInfoRespMsg', handleGetAllMeetings);
@@ -29,3 +30,4 @@ RedisPubSub.on('GuestLobbyMessageChangedEvtMsg', handleGuestLobbyMessageChanged)
 RedisPubSub.on('MeetingTimeRemainingUpdateEvtMsg', handleTimeRemainingUpdate);
 RedisPubSub.on('SelectRandomViewerRespMsg', handleSelectRandomViewer);
 RedisPubSub.on('BroadcastLayoutEvtMsg', handleBroadcastLayout);
+RedisPubSub.on('ModifyWBModeEvtMsg', handleModifyWBMode);

--- a/bigbluebutton-html5/imports/api/meetings/server/handlers/modifyWBMode.js
+++ b/bigbluebutton-html5/imports/api/meetings/server/handlers/modifyWBMode.js
@@ -2,11 +2,9 @@ import modifyWBMode from '../modifiers/modifyWBMode';
 import { check } from 'meteor/check';
 
 export default function handleModifyWBMode({ body }, meetingId) {
-  //const whiteboardId = body.whiteboardId;
   const whiteboardMode = body.whiteboardMode;
 
   check(meetingId, String);
-  //check(whiteboardId, String);
   check(whiteboardMode, Object);
 
   return modifyWBMode(meetingId, whiteboardMode);

--- a/bigbluebutton-html5/imports/api/meetings/server/handlers/modifyWBMode.js
+++ b/bigbluebutton-html5/imports/api/meetings/server/handlers/modifyWBMode.js
@@ -1,0 +1,13 @@
+import modifyWBMode from '../modifiers/modifyWBMode';
+import { check } from 'meteor/check';
+
+export default function handleModifyWBMode({ body }, meetingId) {
+  //const whiteboardId = body.whiteboardId;
+  const whiteboardMode = body.whiteboardMode;
+
+  check(meetingId, String);
+  //check(whiteboardId, String);
+  check(whiteboardMode, Object);
+
+  return modifyWBMode(meetingId, whiteboardMode);
+}

--- a/bigbluebutton-html5/imports/api/meetings/server/methods.js
+++ b/bigbluebutton-html5/imports/api/meetings/server/methods.js
@@ -7,6 +7,7 @@ import toggleWebcamsOnlyForModerator from './methods/toggleWebcamsOnlyForModerat
 import clearRandomlySelectedUser from './methods/clearRandomlySelectedUser';
 import changeLayout from './methods/changeLayout';
 import setWhiteboardMode from './methods/setWhiteboardMode';
+import setVisited from './methods/setVisited';
 
 Meteor.methods({
   endMeeting,
@@ -17,4 +18,5 @@ Meteor.methods({
   clearRandomlySelectedUser,
   changeLayout,
   setWhiteboardMode,
+  setVisited,
 });

--- a/bigbluebutton-html5/imports/api/meetings/server/methods.js
+++ b/bigbluebutton-html5/imports/api/meetings/server/methods.js
@@ -6,6 +6,7 @@ import toggleLockSettings from './methods/toggleLockSettings';
 import toggleWebcamsOnlyForModerator from './methods/toggleWebcamsOnlyForModerator';
 import clearRandomlySelectedUser from './methods/clearRandomlySelectedUser';
 import changeLayout from './methods/changeLayout';
+import setWhiteboardMode from './methods/setWhiteboardMode';
 
 Meteor.methods({
   endMeeting,
@@ -15,4 +16,5 @@ Meteor.methods({
   toggleWebcamsOnlyForModerator,
   clearRandomlySelectedUser,
   changeLayout,
+  setWhiteboardMode,
 });

--- a/bigbluebutton-html5/imports/api/meetings/server/methods/setVisited.js
+++ b/bigbluebutton-html5/imports/api/meetings/server/methods/setVisited.js
@@ -1,0 +1,31 @@
+import Logger from '/imports/startup/server/logger';
+import Meetings from '/imports/api/meetings';
+import { extractCredentials } from '/imports/api/common/server/helpers';
+import { check } from 'meteor/check';
+
+export default function setVisited(visited) {
+  try {
+    const { meetingId, requesterUserId } = extractCredentials(this.userId);
+
+    check(meetingId, String);
+    check(requesterUserId, String);
+    check(visited, Boolean);
+
+    const selector = {
+      meetingId,
+    };
+
+    const modifier = {
+      $set: {
+        visited,
+      },
+    };
+
+    const { insertedId } = Meetings.update(selector, modifier);
+    if (insertedId) {
+      Logger.info(`Set visited for meeting=${meetingId} by id=${requesterUserId}`);
+    }
+  } catch (err) {
+    Logger.error(`Exception while invoking method setVisited ${err.stack}`);
+  }
+}

--- a/bigbluebutton-html5/imports/api/meetings/server/methods/setWhiteboardMode.js
+++ b/bigbluebutton-html5/imports/api/meetings/server/methods/setWhiteboardMode.js
@@ -4,14 +4,19 @@ import { check } from 'meteor/check';
 import { extractCredentials } from '/imports/api/common/server/helpers';
 import Logger from '/imports/startup/server/logger';
 
-export default function setWhiteboardMode(whiteboardMode) {
+export default function setWhiteboardMode(whiteboardMode, credentials) {
   const REDIS_CONFIG = Meteor.settings.private.redis;
   const CHANNEL = REDIS_CONFIG.channels.toAkkaApps;
   const EVENT_NAME = 'ModifyWBModePubMsg';
 
-
+  let meetingId = undefined;
+  let requesterUserId = undefined;
   try {
-    const { meetingId, requesterUserId } = extractCredentials(this.userId);
+    if (this.userId) {
+      ( { meetingId, requesterUserId } = extractCredentials(this.userId) );
+    } else {
+      ( { meetingId, requesterUserId } = credentials );
+    }
 
     check(meetingId, String);
     check(requesterUserId, String);

--- a/bigbluebutton-html5/imports/api/meetings/server/methods/setWhiteboardMode.js
+++ b/bigbluebutton-html5/imports/api/meetings/server/methods/setWhiteboardMode.js
@@ -1,0 +1,30 @@
+import RedisPubSub from '/imports/startup/server/redis';
+import { Meteor } from 'meteor/meteor';
+import { check } from 'meteor/check';
+import { extractCredentials } from '/imports/api/common/server/helpers';
+import Logger from '/imports/startup/server/logger';
+
+export default function setWhiteboardMode(whiteboardMode) {
+  const REDIS_CONFIG = Meteor.settings.private.redis;
+  const CHANNEL = REDIS_CONFIG.channels.toAkkaApps;
+  const EVENT_NAME = 'ModifyWBModePubMsg';
+
+
+  try {
+    const { meetingId, requesterUserId } = extractCredentials(this.userId);
+
+    check(meetingId, String);
+    check(requesterUserId, String);
+//    check(whiteboardId, String);
+
+    //const whiteboardMode = {synchronizeWBUpdate: synchronize };
+    const payload = {
+      whiteboardMode,
+      meetingId,
+    };
+
+    return RedisPubSub.publishUserMessage(CHANNEL, EVENT_NAME, meetingId, requesterUserId, payload);
+  } catch (err) {
+    Logger.error(`Exception while invoking method setWhiteboardMode ${err.stack}`);
+  }
+}

--- a/bigbluebutton-html5/imports/api/meetings/server/methods/setWhiteboardMode.js
+++ b/bigbluebutton-html5/imports/api/meetings/server/methods/setWhiteboardMode.js
@@ -15,9 +15,7 @@ export default function setWhiteboardMode(whiteboardMode) {
 
     check(meetingId, String);
     check(requesterUserId, String);
-//    check(whiteboardId, String);
 
-    //const whiteboardMode = {synchronizeWBUpdate: synchronize };
     const payload = {
       whiteboardMode,
       meetingId,

--- a/bigbluebutton-html5/imports/api/meetings/server/modifiers/addMeeting.js
+++ b/bigbluebutton-html5/imports/api/meetings/server/modifiers/addMeeting.js
@@ -164,9 +164,16 @@ export default function addMeeting(meeting) {
   }
 
   newMeeting.welcomeProp.welcomeMsg = welcomeMsg;
-  
-  const dataSavingSettings = Meteor.settings.public.app.defaultSettings.dataSaving;
-  const { synchronizeWBUpdate = false, simplifyPencil = true } = dataSavingSettings;
+
+  let synchronizeWBUpdate = false;
+  let simplifyPencil = true;
+  if (restProps.meetingProp.isBreakout) {
+    const parentMeeting = Meetings.findOne({meetingId: restProps.breakoutProps.parentId});
+    ({ synchronizeWBUpdate, simplifyPencil } = parentMeeting);
+  } else {
+    const dataSavingSettings = Meteor.settings.public.app.defaultSettings.dataSaving;
+    ({ synchronizeWBUpdate, simplifyPencil } = dataSavingSettings);
+  }
 
   // note: as of July 2020 `modOnlyMessage` is not published to the client side.
   // We are sanitizing this data simply to prevent future potential usage

--- a/bigbluebutton-html5/imports/api/meetings/server/modifiers/addMeeting.js
+++ b/bigbluebutton-html5/imports/api/meetings/server/modifiers/addMeeting.js
@@ -164,6 +164,9 @@ export default function addMeeting(meeting) {
   }
 
   newMeeting.welcomeProp.welcomeMsg = welcomeMsg;
+  
+  const dataSavingSettings = Meteor.settings.public.app.defaultSettings.dataSaving;
+  const { synchronizeWBUpdate = false, simplifyPencil = true } = dataSavingSettings;
 
   // note: as of July 2020 `modOnlyMessage` is not published to the client side.
   // We are sanitizing this data simply to prevent future potential usage
@@ -174,6 +177,8 @@ export default function addMeeting(meeting) {
     $set: Object.assign({
       meetingId,
       meetingEnded,
+      synchronizeWBUpdate,
+      simplifyPencil,
       layout: LAYOUT_TYPE[meeting.usersProp.meetingLayout] || 'smart',
       publishedPoll: false,
       guestLobbyMessage: '',

--- a/bigbluebutton-html5/imports/api/meetings/server/modifiers/modifyWBMode.js
+++ b/bigbluebutton-html5/imports/api/meetings/server/modifiers/modifyWBMode.js
@@ -4,13 +4,8 @@ import Meetings from '/imports/api/meetings/';
 
 export default function modifyWBMode(meetingId, whiteboardMode) {
   check(meetingId, String);
-  //check(whiteboardId, String);
   check(whiteboardMode, Object);
 
-//console.log("API old", meetingId);
-//console.log("API old", Meetings.find().fetch());
-//console.log("API old", Meetings.find({meetingId}).fetch());
-//console.log("API new", meetingId, whiteboardMode);
   const selector = {
     meetingId,
   };
@@ -20,13 +15,6 @@ export default function modifyWBMode(meetingId, whiteboardMode) {
   };
 
   try {
-    //const { insertedId } = WhiteboardMultiUser.upsert(selector, modifier);
-    //if (insertedId) {
-    //  Logger.info(`Added whiteboard style flag=${whiteboardMode} whiteboardId=${whiteboardId}`);
-    //} else {
-    //  Logger.info(`Upserted whiteboard style flag=${whiteboardMode} whiteboardId=${whiteboardId}`);
-    //}
-    //WhiteboardMultiUser.update(selector, modifier);
     Meetings.update(selector, modifier);
     Logger.info(`Updated whiteboard style flag=${whiteboardMode} for meeting=${meetingId}`);
   } catch (err) {

--- a/bigbluebutton-html5/imports/api/meetings/server/modifiers/modifyWBMode.js
+++ b/bigbluebutton-html5/imports/api/meetings/server/modifiers/modifyWBMode.js
@@ -1,0 +1,35 @@
+import { check } from 'meteor/check';
+import Logger from '/imports/startup/server/logger';
+import Meetings from '/imports/api/meetings/';
+
+export default function modifyWBMode(meetingId, whiteboardMode) {
+  check(meetingId, String);
+  //check(whiteboardId, String);
+  check(whiteboardMode, Object);
+
+//console.log("API old", meetingId);
+//console.log("API old", Meetings.find().fetch());
+//console.log("API old", Meetings.find({meetingId}).fetch());
+//console.log("API new", meetingId, whiteboardMode);
+  const selector = {
+    meetingId,
+  };
+
+  const modifier = {
+    $set: whiteboardMode,
+  };
+
+  try {
+    //const { insertedId } = WhiteboardMultiUser.upsert(selector, modifier);
+    //if (insertedId) {
+    //  Logger.info(`Added whiteboard style flag=${whiteboardMode} whiteboardId=${whiteboardId}`);
+    //} else {
+    //  Logger.info(`Upserted whiteboard style flag=${whiteboardMode} whiteboardId=${whiteboardId}`);
+    //}
+    //WhiteboardMultiUser.update(selector, modifier);
+    Meetings.update(selector, modifier);
+    Logger.info(`Updated whiteboard style flag=${whiteboardMode} for meeting=${meetingId}`);
+  } catch (err) {
+    Logger.error(`Error while adding an entry to whiteboard style collection: ${err}`);
+  }
+}

--- a/bigbluebutton-html5/imports/api/meetings/server/modifiers/modifyWBMode.js
+++ b/bigbluebutton-html5/imports/api/meetings/server/modifiers/modifyWBMode.js
@@ -16,7 +16,7 @@ export default function modifyWBMode(meetingId, whiteboardMode) {
 
   try {
     Meetings.update(selector, modifier);
-    Logger.info(`Updated whiteboard style flag=${whiteboardMode} for meeting=${meetingId}`);
+    Logger.info(`Updated whiteboard style sync=${whiteboardMode.synchronizeWBUpdate} simplify=${whiteboardMode.simplifyPencil} for meeting=${meetingId}`);
   } catch (err) {
     Logger.error(`Error while adding an entry to whiteboard style collection: ${err}`);
   }

--- a/bigbluebutton-html5/imports/api/whiteboard-multi-user/server/modifiers/modifyWhiteboardAccess.js
+++ b/bigbluebutton-html5/imports/api/whiteboard-multi-user/server/modifiers/modifyWhiteboardAccess.js
@@ -12,6 +12,7 @@ export default function modifyWhiteboardAccess(meetingId, whiteboardId, multiUse
     whiteboardId,
   };
 
+  //we need to $set them in order not to delete other parameters just in case
   const modifier = {
     $set: {
       meetingId,

--- a/bigbluebutton-html5/imports/api/whiteboard-multi-user/server/modifiers/modifyWhiteboardAccess.js
+++ b/bigbluebutton-html5/imports/api/whiteboard-multi-user/server/modifiers/modifyWhiteboardAccess.js
@@ -13,9 +13,11 @@ export default function modifyWhiteboardAccess(meetingId, whiteboardId, multiUse
   };
 
   const modifier = {
-    meetingId,
-    whiteboardId,
-    multiUser,
+    $set: {
+      meetingId,
+      whiteboardId,
+      multiUser,
+    },
   };
 
   try {

--- a/bigbluebutton-html5/imports/ui/components/settings/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/settings/component.jsx
@@ -80,6 +80,8 @@ const propTypes = {
   dataSaving: PropTypes.shape({
     viewParticipantsWebcams: PropTypes.bool,
     viewScreenshare: PropTypes.bool,
+    synchronizeWBUpdate: PropTypes.bool,
+    simplifyPencil: PropTypes.bool,
   }).isRequired,
   application: PropTypes.shape({
     chatAudioAlerts: PropTypes.bool,

--- a/bigbluebutton-html5/imports/ui/components/settings/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/settings/component.jsx
@@ -241,6 +241,7 @@ class Settings extends Component {
             handleUpdateSettings={this.handleUpdateSettings}
             showToggleLabel={showToggleLabel}
             displaySettingsStatus={this.displaySettingsStatus}
+            isModerator={isModerator}
           />
         </TabPanel>
       </Tabs>

--- a/bigbluebutton-html5/imports/ui/components/settings/service.js
+++ b/bigbluebutton-html5/imports/ui/components/settings/service.js
@@ -3,6 +3,7 @@ import Auth from '/imports/ui/services/auth';
 import Settings from '/imports/ui/services/settings';
 import { notify } from '/imports/ui/services/notification';
 import GuestService from '/imports/ui/components/waiting-users/service';
+import WhiteboardService from '/imports/ui/components/whiteboard/service';
 
 const getUserRoles = () => {
   const user = Users.findOne({
@@ -21,6 +22,14 @@ const showGuestNotification = () => {
 };
 
 const updateSettings = (obj, msg) => {
+  // Update whiteboard mode
+  const dataSaveSetting = obj['dataSaving'];
+  const newWhiteboardMode = {
+    synchronizeWBUpdate: dataSaveSetting.synchronizeWBUpdate,
+    simplifyPencil: dataSaveSetting.simplifyPencil,
+  };
+  WhiteboardService.setWhiteboardMode(newWhiteboardMode);
+  
   Object.keys(obj).forEach(k => (Settings[k] = obj[k]));
   Settings.save();
 

--- a/bigbluebutton-html5/imports/ui/components/settings/submenus/data-saving/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/settings/submenus/data-saving/component.jsx
@@ -6,6 +6,7 @@ import BaseMenu from '../base/component';
 import { styles } from '../styles';
 import WhiteboardService from '/imports/ui/components/whiteboard/service';
 //import PresentationService from '/imports/ui/components/presentation/service';
+import { meetingIsBreakout } from '/imports/ui/components/app/service';
 
 const intlMessages = defineMessages({
   dataSavingLabel: {
@@ -73,6 +74,8 @@ class DataSaving extends BaseMenu {
     //const isPresenter = PresentationService.isPresenter('DEFAULT_PRESENTATION_POD');
     // -> replace isModerator with isPresenter in case we want only the presenter be able to change the whiteboard setting
 
+    const hiddenForBreakout = meetingIsBreakout() && !Meteor.settings.public.app.defaultSettings.dataSaving.changeWBModeBreakout;
+    
     return (
       <div>
         <div>
@@ -124,7 +127,7 @@ class DataSaving extends BaseMenu {
               </div>
             </div>
           </div>
-          {isModerator ?
+          {isModerator && !hiddenForBreakout ?
           <div className={styles.row}>
             <div className={styles.col} aria-hidden="true">
               <div className={styles.formElement}>
@@ -147,7 +150,7 @@ class DataSaving extends BaseMenu {
               </div>
             </div>
           </div> : null}
-          {isModerator && synchronizeWBUpdate ?
+          {isModerator && !hiddenForBreakout && synchronizeWBUpdate ?
           <div className={styles.row}>
             <div className={styles.col} aria-hidden="true">
               <div className={styles.formElement}>

--- a/bigbluebutton-html5/imports/ui/components/settings/submenus/data-saving/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/settings/submenus/data-saving/component.jsx
@@ -5,7 +5,6 @@ import { defineMessages, injectIntl } from 'react-intl';
 import BaseMenu from '../base/component';
 import { styles } from '../styles';
 import WhiteboardService from '/imports/ui/components/whiteboard/service';
-//import PresentationService from '/imports/ui/components/presentation/service';
 import { meetingIsBreakout } from '/imports/ui/components/app/service';
 
 const intlMessages = defineMessages({

--- a/bigbluebutton-html5/imports/ui/components/settings/submenus/data-saving/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/settings/submenus/data-saving/component.jsx
@@ -4,6 +4,8 @@ import Toggle from '/imports/ui/components/switch/component';
 import { defineMessages, injectIntl } from 'react-intl';
 import BaseMenu from '../base/component';
 import { styles } from '../styles';
+import WhiteboardService from '/imports/ui/components/whiteboard/service';
+import PresentationService from '/imports/ui/components/presentation/service';
 
 const intlMessages = defineMessages({
   dataSavingLabel: {
@@ -17,6 +19,14 @@ const intlMessages = defineMessages({
   screenShareLabel: {
     id: 'app.settings.dataSavingTab.screenShare',
     description: 'screenshare toggle',
+  },
+  synchronizeWBUpdateLabel: {
+    id: 'app.settings.dataSavingTab.synchronizeWBUpdate',
+    description: 'whiteboard update synchronization toggle',
+  },
+  simplifyPencilLabel: {
+    id: 'app.settings.dataSavingTab.simplifyPencil',
+    description: 'pencil simplification toggle',
   },
   dataSavingDesc: {
     id: 'app.settings.dataSavingTab.description',
@@ -32,12 +42,35 @@ class DataSaving extends BaseMenu {
       settingsName: 'dataSaving',
       settings: props.settings,
     };
+    
+    const whiteboardMode = WhiteboardService.getWhiteboardMode();
+    if (Object.keys(whiteboardMode).length > 0) {//should be the case
+      if (whiteboardMode.synchronizeWBUpdate != undefined) {
+        this.state.settings.synchronizeWBUpdate = whiteboardMode.synchronizeWBUpdate
+      }
+      if (whiteboardMode.simplifyPencil != undefined) {
+        this.state.settings.simplifyPencil = whiteboardMode.simplifyPencil;
+      }
+    }
+
+    this.handleSyncWBUpdate = this.handleSyncWBUpdate.bind(this);
+    this.handleSimplifyPencil = this.handleSimplifyPencil.bind(this);
+  }
+
+  handleSyncWBUpdate() {
+    this.handleToggle('synchronizeWBUpdate');
+  }
+
+  handleSimplifyPencil() {
+    this.handleToggle('simplifyPencil');
   }
 
   render() {
     const { intl, showToggleLabel, displaySettingsStatus } = this.props;
 
-    const { viewParticipantsWebcams, viewScreenshare } = this.state.settings;
+    const { viewParticipantsWebcams, viewScreenshare, synchronizeWBUpdate, simplifyPencil } = this.state.settings;
+
+    const isPresenter = PresentationService.isPresenter('DEFAULT_PRESENTATION_POD');
 
     return (
       <div>
@@ -90,6 +123,52 @@ class DataSaving extends BaseMenu {
               </div>
             </div>
           </div>
+          {isPresenter ?
+          <div className={styles.row}>
+            <div className={styles.col} aria-hidden="true">
+              <div className={styles.formElement}>
+                <label className={styles.label}>
+                  {intl.formatMessage(intlMessages.synchronizeWBUpdateLabel)}
+                </label>
+              </div>
+            </div>
+            <div className={styles.col}>
+              <div className={cx(styles.formElement, styles.pullContentRight)}>
+                {displaySettingsStatus(synchronizeWBUpdate)}
+                <Toggle
+                  icons={false}
+                  defaultChecked={synchronizeWBUpdate}
+                  onChange={this.handleSyncWBUpdate}
+                  ariaLabelledBy="syncWB"
+                  ariaLabel={intl.formatMessage(intlMessages.synchronizeWBUpdateLabel)}
+                  showToggleLabel={showToggleLabel}
+                />
+              </div>
+            </div>
+          </div> : null}
+          {isPresenter && synchronizeWBUpdate ?
+          <div className={styles.row}>
+            <div className={styles.col} aria-hidden="true">
+              <div className={styles.formElement}>
+                <label className={styles.label}>
+                  {intl.formatMessage(intlMessages.simplifyPencilLabel)}
+                </label>
+              </div>
+            </div>
+            <div className={styles.col}>
+              <div className={cx(styles.formElement, styles.pullContentRight)}>
+                {displaySettingsStatus(simplifyPencil)}
+                <Toggle
+                  icons={false}
+                  defaultChecked={simplifyPencil}
+                  onChange={this.handleSimplifyPencil}
+                  ariaLabelledBy="simplifyPencil"
+                  ariaLabel={intl.formatMessage(intlMessages.simplifyPencilLabel)}
+                  showToggleLabel={showToggleLabel}
+                />
+              </div>
+            </div>
+          </div> : null}
         </div>
       </div>
     );

--- a/bigbluebutton-html5/imports/ui/components/settings/submenus/data-saving/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/settings/submenus/data-saving/component.jsx
@@ -5,7 +5,7 @@ import { defineMessages, injectIntl } from 'react-intl';
 import BaseMenu from '../base/component';
 import { styles } from '../styles';
 import WhiteboardService from '/imports/ui/components/whiteboard/service';
-import PresentationService from '/imports/ui/components/presentation/service';
+//import PresentationService from '/imports/ui/components/presentation/service';
 
 const intlMessages = defineMessages({
   dataSavingLabel: {
@@ -66,11 +66,12 @@ class DataSaving extends BaseMenu {
   }
 
   render() {
-    const { intl, showToggleLabel, displaySettingsStatus } = this.props;
+    const { intl, showToggleLabel, displaySettingsStatus, isModerator } = this.props;
 
     const { viewParticipantsWebcams, viewScreenshare, synchronizeWBUpdate, simplifyPencil } = this.state.settings;
 
-    const isPresenter = PresentationService.isPresenter('DEFAULT_PRESENTATION_POD');
+    //const isPresenter = PresentationService.isPresenter('DEFAULT_PRESENTATION_POD');
+    // -> replace isModerator with isPresenter in case we want only the presenter be able to change the whiteboard setting
 
     return (
       <div>
@@ -123,7 +124,7 @@ class DataSaving extends BaseMenu {
               </div>
             </div>
           </div>
-          {isPresenter ?
+          {isModerator ?
           <div className={styles.row}>
             <div className={styles.col} aria-hidden="true">
               <div className={styles.formElement}>
@@ -146,7 +147,7 @@ class DataSaving extends BaseMenu {
               </div>
             </div>
           </div> : null}
-          {isPresenter && synchronizeWBUpdate ?
+          {isModerator && synchronizeWBUpdate ?
           <div className={styles.row}>
             <div className={styles.col} aria-hidden="true">
               <div className={styles.formElement}>

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/annotation-factory/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/annotation-factory/component.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import StaticAnnotation from './static-annotation/component';
+import StaticAnnotationContainer from './static-annotation/container';
 import ReactiveAnnotationContainer from './reactive-annotation/container';
 import Ellipse from '../annotations/ellipse/component';
 import Line from '../annotations/line/component';
@@ -12,11 +12,12 @@ import Pencil from '../annotations/pencil/component';
 
 const ANNOTATION_CONFIG = Meteor.settings.public.whiteboard.annotations;
 const DRAW_END = ANNOTATION_CONFIG.status.end;
+const DRAW_UPDATE = ANNOTATION_CONFIG.status.update;
 
 export default class AnnotationFactory extends Component {
   static renderStaticAnnotation(annotationInfo, slideWidth, slideHeight, drawObject, whiteboardId) {
     return (
-      <StaticAnnotation
+      <StaticAnnotationContainer
         key={annotationInfo._id}
         shapeId={annotationInfo._id}
         drawObject={drawObject}
@@ -48,7 +49,7 @@ export default class AnnotationFactory extends Component {
   renderAnnotation(annotationInfo) {
     const drawObject = this.props.annotationSelector[annotationInfo.annotationType];
 
-    if (annotationInfo.status === DRAW_END) {
+    if (this.props.published) {
       return AnnotationFactory.renderStaticAnnotation(
         annotationInfo,
         this.props.slideWidth,
@@ -56,14 +57,15 @@ export default class AnnotationFactory extends Component {
         drawObject,
         this.props.whiteboardId,
       );
+    } else {
+      return AnnotationFactory.renderReactiveAnnotation(
+        annotationInfo,
+        this.props.slideWidth,
+        this.props.slideHeight,
+        drawObject,
+        this.props.whiteboardId,
+      );
     }
-    return AnnotationFactory.renderReactiveAnnotation(
-      annotationInfo,
-      this.props.slideWidth,
-      this.props.slideHeight,
-      drawObject,
-      this.props.whiteboardId,
-    );
   }
 
   render() {

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/annotation-factory/static-annotation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/annotation-factory/static-annotation/component.jsx
@@ -3,9 +3,10 @@ import PropTypes from 'prop-types';
 import StaticAnnotationService from './service';
 
 export default class StaticAnnotation extends React.Component {
-  // completed annotations should never update
-  shouldComponentUpdate() {
-    return false;
+  // completed annotations can be updated for synchronized drawing
+  shouldComponentUpdate(nextProps) {
+    const { version } = this.props;
+    return version !== nextProps.version;
   }
 
   render() {

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/annotation-factory/static-annotation/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/annotation-factory/static-annotation/container.jsx
@@ -5,9 +5,6 @@ import StaticAnnotation from './component';
 import StaticAnnotationService from './service';
 import ReactiveAnnotationService from '../reactive-annotation/service';
 
-//import { Annotations } from '/imports/ui/components/whiteboard/service';
-//import { UnsentAnnotations } from '/imports/ui/components/whiteboard/service';
-
 const StaticAnnotationContainer = (props) => {
   return (
     <StaticAnnotation
@@ -21,19 +18,10 @@ export default withTracker((params) => {
     shapeId,
   } = params;
 
-//console.log("STATIC_CONT", shapeId, params.whiteboardId);
-//console.log(Annotations.find({whiteboardId: params.whiteboardId}).fetch());
   const annotation = StaticAnnotationService.getAnnotationById(shapeId);
-  //var annotation = StaticAnnotationService.getAnnotationById(shapeId);
-  if (!annotation){
-//console.log(UnsentAnnotations.find({whiteboardId: params.whiteboardId}).fetch());
-//console.log(UnsentAnnotations.findOne({_id: shapeId}));
-console.log("FACTORY no annotation found! ShapeId:", shapeId);
-    //annotation = ReactiveAnnotationService.getAnnotationById(shapeId);
-  }
 
   return {
-    // This is necessary to real-time update the movement. Otherwise the prop.version is undefined in the component.jsx
+    // This is necessary to real-time update the movement
     version: annotation.version,
   };
 })(StaticAnnotationContainer);

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/annotation-factory/static-annotation/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/annotation-factory/static-annotation/container.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { withTracker } from 'meteor/react-meteor-data';
 import StaticAnnotation from './component';
 import StaticAnnotationService from './service';
-import ReactiveAnnotationService from '../reactive-annotation/service';
 
 const StaticAnnotationContainer = (props) => {
   return (

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/annotation-factory/static-annotation/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/annotation-factory/static-annotation/container.jsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { withTracker } from 'meteor/react-meteor-data';
+import StaticAnnotation from './component';
+import StaticAnnotationService from './service';
+import ReactiveAnnotationService from '../reactive-annotation/service';
+
+//import { Annotations } from '/imports/ui/components/whiteboard/service';
+//import { UnsentAnnotations } from '/imports/ui/components/whiteboard/service';
+
+const StaticAnnotationContainer = (props) => {
+  return (
+    <StaticAnnotation
+      {...props}
+    />
+  );
+};
+
+export default withTracker((params) => {
+  const {
+    shapeId,
+  } = params;
+
+//console.log("STATIC_CONT", shapeId, params.whiteboardId);
+//console.log(Annotations.find({whiteboardId: params.whiteboardId}).fetch());
+  const annotation = StaticAnnotationService.getAnnotationById(shapeId);
+  //var annotation = StaticAnnotationService.getAnnotationById(shapeId);
+  if (!annotation){
+//console.log(UnsentAnnotations.find({whiteboardId: params.whiteboardId}).fetch());
+//console.log(UnsentAnnotations.findOne({_id: shapeId}));
+console.log("FACTORY no annotation found! ShapeId:", shapeId);
+    //annotation = ReactiveAnnotationService.getAnnotationById(shapeId);
+  }
+
+  return {
+    // This is necessary to real-time update the movement. Otherwise the prop.version is undefined in the component.jsx
+    version: annotation.version,
+  };
+})(StaticAnnotationContainer);
+
+StaticAnnotationContainer.propTypes = {
+  whiteboardId: PropTypes.string.isRequired,
+  annotation: PropTypes.objectOf(PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number,
+    PropTypes.object,
+  ])),
+  drawObject: PropTypes.func.isRequired,
+  slideWidth: PropTypes.number.isRequired,
+  slideHeight: PropTypes.number.isRequired,
+};

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/annotation-group/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/annotation-group/component.jsx
@@ -8,6 +8,7 @@ const AnnotationGroup = props => (
     slideWidth={props.slideWidth}
     slideHeight={props.slideHeight}
     whiteboardId={props.whiteboardId}
+    published={props.published}
   />
 );
 

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/annotation-group/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/annotation-group/container.jsx
@@ -5,13 +5,14 @@ import AnnotationGroupService from './service';
 import AnnotationGroup from './component';
 
 const AnnotationGroupContainer = ({
-  annotationsInfo, width, height, whiteboardId,
+  annotationsInfo, width, height, whiteboardId, published,
 }) => (
   <AnnotationGroup
     annotationsInfo={annotationsInfo}
     slideWidth={width}
     slideHeight={height}
     whiteboardId={whiteboardId}
+    published={published}
   />
 );
 

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/annotations/pencil/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/annotations/pencil/component.jsx
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import WhiteboardService from '../../service';
 import { getFormattedColor, getStrokeWidth, denormalizeCoord } from '../helpers';
 
 export default class PencilDrawComponent extends Component {
@@ -78,6 +79,8 @@ export default class PencilDrawComponent extends Component {
 
     const { annotation, slideWidth, slideHeight } = this.props;
 
+    this.whiteboardMode = WhiteboardService.getWhiteboardMode();
+
     this.path = this.getCoordinates(annotation, slideWidth, slideHeight);
 
     this.getCurrentPath = this.getCurrentPath.bind(this);
@@ -85,30 +88,30 @@ export default class PencilDrawComponent extends Component {
   }
 
   shouldComponentUpdate(nextProps) {
-    const { version } = this.props;
+    const { version, annotation, slideWidth, slideHeight } = this.props;
+    const { points } = annotation;
+    if (points.length !== nextProps.annotation.points.length) {
+      // this has been transferred from componentDidUpdate to reach to the last point
+      this.path = this.getCoordinates(nextProps.annotation, slideWidth, slideHeight);
+    }
     return version !== nextProps.version;
   }
 
-  componentDidUpdate(prevProps) {
-    const { annotation: prevAnnotation } = prevProps;
-    const { points: prevPoints } = prevAnnotation;
-    const { annotation, slideWidth, slideHeight } = this.props;
-    const { points } = annotation;
-    if (prevPoints.length !== points.length) {
-      this.path = this.getCoordinates(annotation, slideWidth, slideHeight);
-    }
-  }
-
   getCoordinates(annotation, slideWidth, slideHeight) {
-    if ((!annotation || annotation.points.length === 0)
-        || (annotation.status === 'DRAW_END' && !annotation.commands)) {
+    if (!annotation || annotation.points.length === 0) {
       return undefined;
     }
 
+    // When the screen is reloaded, whiteboard mode can differ from what was set when the annotation was initially drawn,
+    //  thus we judge if the drawing is bezier similified by the presence of annotation.commands
     let data;
     // Final message, display smoothes coordinates
     if (annotation.status === 'DRAW_END') {
-      data = PencilDrawComponent.getFinalCoordinates(annotation, slideWidth, slideHeight);
+      if (annotation.commands) {
+        data = PencilDrawComponent.getFinalCoordinates(annotation, slideWidth, slideHeight);
+      } else {
+        data = PencilDrawComponent.getInitialCoordinates(annotation, slideWidth, slideHeight);
+      }
     // Not a final message, but rendering it for the first time, creating a new path
     } else if (!this.path) {
       data = PencilDrawComponent.getInitialCoordinates(annotation, slideWidth, slideHeight);

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/service.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/service.js
@@ -34,7 +34,7 @@ function handleAddedAnnotation({
   const isOwn = Auth.meetingID === meetingId && Auth.userID === userId;
   let query = addAnnotationQuery(meetingId, whiteboardId, userId, annotation);
 
-  if (!Annotations.findOne(query.selector) && annotation.status == 'DRAW_UPDATE') { // Can we remove REALTIMEUPDATE condition here??? - need to check.
+  if (!Annotations.findOne(query.selector) && annotation.status == 'DRAW_UPDATE') {
     // When DRAW_UPDATE arrives for the first time (without DRAW_START), this dirty solution is necessary..
     const statusOriginal = annotation.status;
     annotation.status = 'DRAW_START';

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/service.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/service.js
@@ -227,10 +227,12 @@ const sendAnnotation = (annotation, synchronizeWBUpdate) => {
             // send all accumulated points in the reservoir
             if (annotationsReservoir.length > 0) {
               newAnnotation = annotationWithNewPoints(annotationsReservoir[annotationsReservoir.length -1], accumulatedPoints);
+              annotationsQueue.push(newAnnotation);
             }
           } else {
             // send all accumulated points in the reservoir plus the new points,
             newAnnotation = annotationWithNewPoints(annotation, accumulatedPoints.concat(...annotation.annotationInfo.points));
+            annotationsQueue.push(newAnnotation);
             // To drain the first path left in the reservoir after a while
             //  (e.g. when we pause drawing after the first stroke),
             //  judging if it's the first one by looking at the UnsentAnnotations being empty
@@ -239,7 +241,6 @@ const sendAnnotation = (annotation, synchronizeWBUpdate) => {
               sendEmptyAnnotation(annotation, synchronizeWBUpdate);
             }
           }
-          annotationsQueue.push(newAnnotation);
         } else { // shape or text drawing
           if (annotation.status === DRAW_NONE) {
             if (annotationsReservoir.length > 0) {

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/service.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/service.js
@@ -261,7 +261,6 @@ const sendAnnotation = (annotation, synchronizeWBUpdate) => {
         // This will make a sendAnnotation loop until the drawing ends,
         //  which will not matter as it is just a internal process.
         const isStillDrawing = UnsentAnnotations.find({meetingId: Auth.meetingID, userId: Auth.userID, id: annotation.id}, {limit: 1}).count() > 0;
-
         if (isStillDrawing) {
           sendEmptyAnnotation(annotation, synchronizeWBUpdate);
         }

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/service.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/service.js
@@ -297,7 +297,9 @@ const sendAnnotation = (annotation, synchronizeWBUpdate) => {
 
     if (synchronizeWBUpdate && annotationType === ANNOTATION_TYPE_PENCIL) {
       // For drawing a point by pencil, DRAW_START must be included,
-      //  but it will be used only for the fake annotations (i.e. those in the presenter's screen)
+      //  but it will be used only for the fake annotations (i.e. those in the presenter's screen).
+      //  - I decided not to send DRAW_START, which is not essential, to akka-apps to slightly reduce the traffic.
+      //  However the code would be more straight if we simply revive DRAW_START in akka-apps.
       queryFake.modifier['$push'] = {'annotationInfo.points' : { '$each': annotation.annotationInfo.points } };
     }
 

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/service.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/service.js
@@ -258,10 +258,11 @@ const sendAnnotation = (annotation, synchronizeWBUpdate) => {
         if (!annotationsSenderIsRunning) setTimeout(proccessAnnotationsQueue, annotationsBufferTimeMin);
 
         // We do this in order to drain the reservoir after a while (to draw even when we pause)
-        // After sending an empty annotation, we don't send another,
-        //  which will make an infinite loop until the drawing ends
-        const isStillDrawing = UnsentAnnotations.find({meetingId: Auth.meetingID, userId: Auth.userID, id: annotation.id}, {limit: 1}).count();
-        if (isStillDrawing && annotation.status !== DRAW_NONE) {
+        // This will make a sendAnnotation loop until the drawing ends,
+        //  which will not matter as it is just a internal process.
+        const isStillDrawing = UnsentAnnotations.find({meetingId: Auth.meetingID, userId: Auth.userID, id: annotation.id}, {limit: 1}).count() > 0;
+
+        if (isStillDrawing) {
           sendEmptyAnnotation(annotation, synchronizeWBUpdate);
         }
         // drain the reservoir

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/service.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/service.js
@@ -440,6 +440,7 @@ export {
   changeWhiteboardAccess,
   addGlobalAccess,
   addIndividualAccess,
+  setVisited,
   setWhiteboardMode,
   getWhiteboardMode,
   removeGlobalAccess,

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/service.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/service.js
@@ -170,11 +170,10 @@ const annotationWithNewPoints = (annotation, points) => {
     ...annotation.annotationInfo,
     points,
   };
-  const newAnnotation = {
+  return {
     ...annotation,
     annotationInfo: newAnnotationInfo,
   };
-  return newAnnotation;
 }
 
 const sendEmptyAnnotation = (an, sync) => {

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/service.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/service.js
@@ -400,16 +400,25 @@ const addIndividualAccess = (whiteboardId, userId) => {
   makeCall('addIndividualAccess', whiteboardId, userId);
 };
 
-const setWhiteboardMode = (whiteboardMode) => {
-  makeCall('setWhiteboardMode', whiteboardMode);
-}
-
-const getWhiteboardMode = () => {
-  const style = Meetings.findOne({meetingId: Auth.meetingID}, { fields: {synchronizeWBUpdate:1, simplifyPencil:1}});
-  delete style._id;
-  return style;
+const setVisited = (visited) => {
+  makeCall('setVisited', visited);
 };
 
+const setWhiteboardMode = (whiteboardMode, credentials) => {
+  makeCall('setWhiteboardMode', whiteboardMode, credentials);
+};
+
+const getWhiteboardMode = (meetingId) => {
+  const mid = meetingId ? meetingId : Auth.meetingID;
+  const style = Meetings.findOne({meetingId: mid}, { fields: {synchronizeWBUpdate:1, simplifyPencil:1}});
+  if (style) {
+    delete style._id;
+    return style;
+  } else {
+    return {};
+  }
+};
+  
 const removeGlobalAccess = (whiteboardId) => {
   makeCall('removeGlobalAccess', whiteboardId);
 };

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/service.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/service.js
@@ -37,7 +37,7 @@ function handleAddedAnnotation({
   let query = addAnnotationQuery(meetingId, whiteboardId, userId, annotation);
 
   if ( Annotations.find(query.selector, {limit: 1}).count() === 0 && annotation.status == 'DRAW_UPDATE' ) {
-    // When DRAW_UPDATE arrives for the first time (without DRAW_START), this dirty solution is necessary..
+    // When DRAW_UPDATE arrives for the first time, this dirty solution is necessary due to the lack of DRAW_START
     const statusOriginal = annotation.status;
     annotation.status = 'DRAW_START';
     query = addAnnotationQuery(meetingId, whiteboardId, userId, annotation);
@@ -127,7 +127,7 @@ const annotationsQueue = [];
 // How many packets we need to have to use annotationsBufferTimeMax
 const annotationsMaxDelayQueueSize = 60;
 // Minimum bufferTime
-const annotationsBufferTimeMin = 30; // can be larger for the synchronized updating?
+const annotationsBufferTimeMin = 30; // can be a different value for the synchronized updating?
 // Maximum bufferTime
 const annotationsBufferTimeMax = 200;
 // Time before running 'sendBulkAnnotations' again if user is offline

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-overlay/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-overlay/component.jsx
@@ -164,6 +164,7 @@ export default class WhiteboardOverlay extends Component {
       physicalSlideHeight,
       slideWidth,
       slideHeight,
+      synchronizeWBUpdate,
     } = this.props;
 
     const { tool } = drawSettings;
@@ -176,6 +177,7 @@ export default class WhiteboardOverlay extends Component {
             actions={actions}
             drawSettings={drawSettings}
             whiteboardId={whiteboardId}
+            synchronizeWBUpdate={synchronizeWBUpdate}
           />
         );
       }
@@ -186,6 +188,7 @@ export default class WhiteboardOverlay extends Component {
           actions={actions}
           drawSettings={drawSettings}
           whiteboardId={whiteboardId}
+          synchronizeWBUpdate={synchronizeWBUpdate}
         />
       );
     } if (tool === 'pencil') {
@@ -198,6 +201,7 @@ export default class WhiteboardOverlay extends Component {
             actions={actions}
             physicalSlideWidth={physicalSlideWidth}
             physicalSlideHeight={physicalSlideHeight}
+            synchronizeWBUpdate={synchronizeWBUpdate}
           />
         );
       }
@@ -210,6 +214,7 @@ export default class WhiteboardOverlay extends Component {
           actions={actions}
           physicalSlideWidth={physicalSlideWidth}
           physicalSlideHeight={physicalSlideHeight}
+          synchronizeWBUpdate={synchronizeWBUpdate}
         />
       );
     } if (tool === 'text') {
@@ -221,6 +226,7 @@ export default class WhiteboardOverlay extends Component {
           actions={actions}
           slideWidth={slideWidth}
           slideHeight={slideHeight}
+          synchronizeWBUpdate={synchronizeWBUpdate}
         />
       );
     }

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-overlay/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-overlay/container.jsx
@@ -4,9 +4,28 @@ import PropTypes from 'prop-types';
 import WhiteboardOverlayService from './service';
 import WhiteboardOverlay from './component';
 import WhiteboardService from '../service';
+import Meetings from '/imports/api/meetings';
+import Auth from '/imports/ui/services/auth';
+import { makeCall } from '/imports/ui/services/api';
 
 const WhiteboardOverlayContainer = (props) => {
   const { drawSettings } = props;
+  
+  // Updating the whiteboard mode for the breakout room.
+  // Note that doing this when the breakout room is created is a more elegant solution,
+  //  but it would be much complicated and there is a risk to break something else.
+  const meeting = Meetings.findOne({meetingId: Auth.meetingID}, { fields: {meetingProp:1, visited:1}});
+  if ( meeting.meetingProp.isBreakout && !meeting.visited ){
+    WhiteboardService.setVisited(true);
+    // The first one who enters the breakout room has to do this.
+    // I decided to add the member "visited".
+    // Another option is to check the number of users in the room,
+    //  but there is a race condition where somebody enters before creating the whiteboard overlay.
+
+    WhiteboardService.setWhiteboardMode(WhiteboardService.getWhiteboardMode(), {meetingId: Auth.meetingID, requesterUserId: Auth.userId});
+    // We need this because the whiteboard mode set at the modifier API addMeeting.js has not reached to the akka-app.
+  }
+  
   if (Object.keys(drawSettings).length > 0) {
     return (
       <WhiteboardOverlay {...props} />

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-overlay/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-overlay/container.jsx
@@ -3,6 +3,7 @@ import { withTracker } from 'meteor/react-meteor-data';
 import PropTypes from 'prop-types';
 import WhiteboardOverlayService from './service';
 import WhiteboardOverlay from './component';
+import WhiteboardService from '../service';
 
 const WhiteboardOverlayContainer = (props) => {
   const { drawSettings } = props;
@@ -23,6 +24,7 @@ export default withTracker(() => ({
   drawSettings: WhiteboardOverlayService.getWhiteboardToolbarValues(),
   userId: WhiteboardOverlayService.getCurrentUserId(),
   updateCursor: WhiteboardOverlayService.updateCursor,
+  synchronizeWBUpdate: WhiteboardService.getWhiteboardMode().synchronizeWBUpdate,
 }))(WhiteboardOverlayContainer);
 
 

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-overlay/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-overlay/container.jsx
@@ -6,7 +6,6 @@ import WhiteboardOverlay from './component';
 import WhiteboardService from '../service';
 import Meetings from '/imports/api/meetings';
 import Auth from '/imports/ui/services/auth';
-import { makeCall } from '/imports/ui/services/api';
 
 const WhiteboardOverlayContainer = (props) => {
   const { drawSettings } = props;

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-overlay/pencil-draw-listener/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-overlay/pencil-draw-listener/component.jsx
@@ -19,7 +19,6 @@ export default class PencilDrawListener extends Component {
     // to track the status of drawing
     this.isDrawing = false;
     this.points = [];
-    this.updateBeforeEnd = false; //for drawing a point by a single click by synchronously updating pencil
 
     this.mouseDownHandler = this.mouseDownHandler.bind(this);
     this.mouseMoveHandler = this.mouseMoveHandler.bind(this);
@@ -173,13 +172,12 @@ export default class PencilDrawListener extends Component {
       } = this.props;
 
       const { getCurrentShapeId } = actions;
-      this.updateBeforeEnd = true;
       this.handleDrawPencil(this.points, DRAW_UPDATE, getCurrentShapeId());
       this.points = []; // only new points will be sent
     }
   }
 
-  handleDrawPencil(points, status, id, dimensions, updateBeforeEnd) {
+  handleDrawPencil(points, status, id, dimensions) {
     const {
       whiteboardId,
       userId,
@@ -198,11 +196,6 @@ export default class PencilDrawListener extends Component {
       color,
     } = drawSettings;
 
-    var pencilPoint = undefined;
-    if (status == DRAW_END) {
-      pencilPoint = updateBeforeEnd ? false : true;
-    }
-
     const annotation = {
       id,
       status,
@@ -219,7 +212,6 @@ export default class PencilDrawListener extends Component {
       wbId: whiteboardId,
       userId,
       position: 0,
-      pencilPoint,
     };
 
     // dimensions are added to the 'DRAW_END', last message
@@ -245,9 +237,7 @@ export default class PencilDrawListener extends Component {
         DRAW_END,
         getCurrentShapeId(),
         [Math.round(physicalSlideWidth), Math.round(physicalSlideHeight)],
-        this.updateBeforeEnd,
       );
-      this.updateBeforeEnd = false;
       this.resetState();
     }
   }

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-overlay/pencil-draw-listener/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-overlay/pencil-draw-listener/component.jsx
@@ -196,6 +196,12 @@ export default class PencilDrawListener extends Component {
       color,
     } = drawSettings;
 
+    if (status == DRAW_END && synchronizeWBUpdate && points.length === 2) {
+      //to ensure a point is drawn by a single click,
+      // with a risk of unnecessary point added also for a normal drawing
+      points = points.concat(points);
+    }
+    
     const annotation = {
       id,
       status,

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-overlay/pencil-draw-listener/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-overlay/pencil-draw-listener/component.jsx
@@ -197,8 +197,9 @@ export default class PencilDrawListener extends Component {
     } = drawSettings;
 
     if (status == DRAW_END && synchronizeWBUpdate && points.length === 2) {
-      //to ensure a point is drawn by a single click,
-      // with a risk of unnecessary point added also for a normal drawing
+      // To ensure a point is drawn by a single click,
+      //  with a risk of unnecessary point added also for a normal drawing
+      // If we simply revive sending DRAW_START to akka-apps, this would not be necessary (see whiteboard/service.js).
       points = points.concat(points);
     }
     

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-overlay/pencil-pointer-listener/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-overlay/pencil-pointer-listener/component.jsx
@@ -135,6 +135,7 @@ export default class PencilPointerListener extends Component {
     } = drawSettings;
 
     if (status == DRAW_END && synchronizeWBUpdate && points.length === 2) {
+      // see the comment in pencil-draw-listner
       points = points.concat(points);
     }
 

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-overlay/pencil-pointer-listener/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-overlay/pencil-pointer-listener/component.jsx
@@ -22,7 +22,6 @@ export default class PencilPointerListener extends Component {
     this.isDrawing = false;
     this.palmRejectionActivated = Storage.getItem(PALM_REJECTION_MODE);
     this.points = [];
-    this.updateBeforeEnd = false;
 
     this.handlePointerDown = this.handlePointerDown.bind(this);
     this.handlePointerUp = this.handlePointerUp.bind(this);
@@ -111,13 +110,12 @@ export default class PencilPointerListener extends Component {
       } = this.props;
 
       const { getCurrentShapeId } = actions;
-      this.updateBeforeEnd = true;
       this.handleDrawPencil(this.points, DRAW_UPDATE, getCurrentShapeId());
       this.points = [];
     }
   }
 
-  handleDrawPencil(points, status, id, dimensions, updateBeforeEnd) {
+  handleDrawPencil(points, status, id, dimensions) {
     const {
       whiteboardId,
       userId,
@@ -136,9 +134,8 @@ export default class PencilPointerListener extends Component {
       color,
     } = drawSettings;
 
-    var pencilPoint = undefined;
-    if (status == DRAW_END) {
-      pencilPoint = updateBeforeEnd ? false : true;
+    if (status == DRAW_END && synchronizeWBUpdate && points.length === 2) {
+      points = points.concat(points);
     }
 
     const annotation = {
@@ -157,7 +154,6 @@ export default class PencilPointerListener extends Component {
       wbId: whiteboardId,
       userId,
       position: 0,
-      pencilPoint,
     };
 
     // dimensions are added to the 'DRAW_END', last message
@@ -183,9 +179,7 @@ export default class PencilPointerListener extends Component {
         DRAW_END,
         getCurrentShapeId(),
         [Math.round(physicalSlideWidth), Math.round(physicalSlideHeight)],
-        this.updateBeforeEnd,
       );
-      this.updateBeforeEnd = false;
       this.resetState();
     }
   }

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-overlay/shape-draw-listener/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-overlay/shape-draw-listener/component.jsx
@@ -283,6 +283,7 @@ export default class ShapeDrawListener extends Component {
       userId,
       actions,
       drawSettings,
+      synchronizeWBUpdate,
     } = this.props;
 
     const {
@@ -318,7 +319,7 @@ export default class ShapeDrawListener extends Component {
       position: 0,
     };
 
-    sendAnnotation(annotation, whiteboardId);
+    sendAnnotation(annotation, synchronizeWBUpdate);
   }
 
   discardAnnotation() {

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-overlay/shape-pointer-listener/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-overlay/shape-pointer-listener/component.jsx
@@ -218,6 +218,7 @@ export default class ShapePointerListener extends Component {
       userId,
       actions,
       drawSettings,
+      synchronizeWBUpdate,
     } = this.props;
 
     const {
@@ -253,7 +254,7 @@ export default class ShapePointerListener extends Component {
       position: 0,
     };
 
-    sendAnnotation(annotation, whiteboardId);
+    sendAnnotation(annotation, synchronizeWBUpdate);
   }
 
   discardAnnotation() {

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-overlay/text-draw-listener/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-overlay/text-draw-listener/component.jsx
@@ -442,6 +442,7 @@ export default class TextDrawListener extends Component {
       userId,
       actions,
       drawSettings,
+      synchronizeWBUpdate,
     } = this.props;
 
     const {
@@ -478,7 +479,7 @@ export default class TextDrawListener extends Component {
       position: 0,
     };
 
-    sendAnnotation(annotation, whiteboardId);
+    sendAnnotation(annotation, synchronizeWBUpdate);
   }
 
   discardAnnotation() {

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -160,6 +160,9 @@ public:
       dataSaving:
         viewParticipantsWebcams: true
         viewScreenshare: true
+        synchronizeWBUpdate: false
+        simplifyPencil: true
+        syncPencilPointsToBuffer: 5
     shortcuts:
       openOptions:
         accesskey: O

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -162,6 +162,7 @@ public:
         viewScreenshare: true
         synchronizeWBUpdate: false
         simplifyPencil: true
+        changeWBModeBreakout: false
         syncPencilPointsToBuffer: 2
         intervalDrainResevoir: 500
     shortcuts:

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -162,7 +162,7 @@ public:
         viewScreenshare: true
         synchronizeWBUpdate: false
         simplifyPencil: true
-        syncPencilPointsToBuffer: 5
+        syncPencilPointsToBuffer: 4
     shortcuts:
       openOptions:
         accesskey: O

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -162,7 +162,8 @@ public:
         viewScreenshare: true
         synchronizeWBUpdate: false
         simplifyPencil: true
-        syncPencilPointsToBuffer: 4
+        syncPencilPointsToBuffer: 2
+        intervalDrainResevoir: 500
     shortcuts:
       openOptions:
         accesskey: O
@@ -651,6 +652,7 @@ public:
         start: DRAW_START
         update: DRAW_UPDATE
         end: DRAW_END
+        none: DRAW_NONE
     toolbar:
       multiUserPenOnly: false
       colors:

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -404,6 +404,8 @@
     "app.settings.dataSavingTab.label": "Data savings",
     "app.settings.dataSavingTab.webcam": "Enable other participants webcams",
     "app.settings.dataSavingTab.screenShare": "Enable desktop sharing",
+    "app.settings.dataSavingTab.synchronizeWBUpdate": "Synchronize whiteboard update",
+    "app.settings.dataSavingTab.simplifyPencil": "Simplify pencil drawing",
     "app.settings.dataSavingTab.description": "To save your bandwidth adjust what's currently being displayed.",
     "app.settings.save-notification.label": "Settings have been saved",
     "app.statusNotifier.lowerHands": "Lower Hands",


### PR DESCRIPTION
### What does this PR do?

Revives the real-time (synchronised) annotation update of whiteboard, which has been removed since 2.3.x due to the scalability reason. In contrast to 2.2.x, it offers a throttling function, which sends the drawing data intermittently. This PR also adds the possibility to turn off the smoothing/simplification (approximation by Bezier curve) of pen drawing.

Only moderators can turn it on at the data-saving panel. When the synchronised update is on, they can turn on/off the simplification function.

You can turn them on by default by changing new parameters in settings.yml, although not recommended.

> synchronizeWBUpdate: false
> simplifyPencil: true

There are three additional settings.

> changeWBModeBreakout: false  (if true, users - moderators - in a breakout can change the setting)
> syncPencilPointsToBuffer: 2 (number of mouse points stored before sent to the presenter's screen and eventually to the server)
> intervalDrainResevoir: 500 (ms intervals to update annotations on the viewer's screens)

"syncPencilPointsToBuffer" affects both on the presenter's drawing (always synchronised) and on this drawing shown on the viewer's screen, while "intervalDrainResevoir" only affects the viewer's screen.
When you set "syncPencilPointsToBuffer" 2, the drawing proceeds after every two mouse events, if set 4, every 3 mouse events (for value n, n/2+1 mouse events). Increasing this value will slightly improve the network traffic, but undoubtedly impair the presenter's experience. It may be good to increase it if you use a very old laptop as a presenter (such as 5, as on 2.2.x). But  even setting it 0 seems not increase the traffic, probably because it became an internal communication since 2.3.x.
"intervalDrainResevoir" is much more important. I have tested and found out that updating every 0.5 sec (default setting) is very much acceptable, minimising the network load,  and yet providing a much better user's experience in the viewer's side than without the synchronised update at all.

The behaviour in breakout rooms have been discussed intensively in the issue below. It would be safe to set "changeWBModeBreakout" false. If you want to turn it on in breakouts, you do so on in the parent meeting before creating breakouts, the setting will be inherited.

### Closes Issue(s)



### Motivation

I don't want to be misunderstood that I hate the new whiteboard feature since 2.3; I love it actually. But there are certainly unignorable number of people that really need the real time update of whiteboard drawings (e.g. language teachers who need to show how to write letters). For those people, administrators need to keep unsecure 2.2.x servers. This PR may help such admins to migrate to 2.4.x that still meets the users' requirements.

### More

A couple of minor problems.
1. I haven't tested the palm rejection function.. do I need the super expensive Apple pen to do so?
2. I have realised a race condition where the moderator changes the setting during the users are drawing by pencil. You may have some points missing or have a weird pen drawing which connects the start and the end.
3. I don't think this is the best implementation. I used some dirty hack in some places. And I did not test it extensively in a real lecture/meeting. Please suggest if somebody finds errors/issues.
4. A possibility to turn it on/off automatically depending on the [network load / number of participants / multiuser whiteboard on/off] has been discussed, but I decided to leave it open (see the discussion on the issue). You may have to warn the users about the risk of high network load. No warning toast pops up for now.

![Animation1](https://user-images.githubusercontent.com/45039819/148341190-e559ea03-7e34-4460-8439-9f22716b15c2.gif)

