### PR TITLE
feat(closed caption) Quick navigation of caption locales and the choice is remembered

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/captions/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/captions/component.jsx
@@ -44,7 +44,6 @@ const handleClickCaption = (locale, selectedLocale) => {
   if (selectedLocale != locale) {
     Storage.setItem(CAPTION_LOCALE, locale);
     Session.set('activeCaptions', locale);
-    //CaptionsService.setActiveCaptions(locale);
   }
 }
 

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/captions/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/captions/component.jsx
@@ -4,6 +4,18 @@ import cx from 'classnames';
 import { defineMessages, injectIntl } from 'react-intl';
 import { styles } from '/imports/ui/components/actions-bar/styles';
 import Button from '/imports/ui/components/button/component';
+import ButtonEmoji from '/imports/ui/components/button/button-emoji/ButtonEmoji';
+import CaptionsService from '/imports/ui/components/captions/service';
+import { Session } from 'meteor/session';
+import _ from 'lodash';
+import Dropdown from '/imports/ui/components/dropdown/component';
+import DropdownTrigger from '/imports/ui/components/dropdown/trigger/component';
+import DropdownContent from '/imports/ui/components/dropdown/content/component';
+import DropdownList from '/imports/ui/components/dropdown/list/component';
+import DropdownListItem from '/imports/ui/components/dropdown/list/item/component';
+import Storage from '/imports/ui/services/storage/session';
+
+const CAPTION_LOCALE = 'captionLocale';
 
 const propTypes = {
   intl: PropTypes.shape({
@@ -22,21 +34,65 @@ const intlMessages = defineMessages({
     id: 'app.actionsBar.captions.stop',
     description: 'Stop closed captions option',
   },
+  changeCaption: {
+    id: 'app.actionsBar.changeCaption',
+    description: 'Open change caption label',
+  },
 });
 
-const CaptionsButton = ({ intl, isActive, handleOnClick }) => (
-  <Button
-    className={cx(isActive || styles.btn)}
-    icon="closed_caption"
-    label={intl.formatMessage(isActive ? intlMessages.stop : intlMessages.start)}
-    color={isActive ? 'primary' : 'default'}
-    ghost={!isActive}
-    hideLabel
-    circle
-    size="lg"
-    onClick={handleOnClick}
-    id={isActive ? 'stop-captions-button' : 'start-captions-button'}
-  />
+const handleClickCaption = (locale, selectedLocale) => {
+  if (selectedLocale != locale) {
+    Storage.setItem(CAPTION_LOCALE, locale);
+    Session.set('activeCaptions', locale);
+    //CaptionsService.setActiveCaptions(locale);
+  }
+}
+
+const getAvailableCaptions = (captions, selected) => {
+  return(
+    captions.map(locale => (
+    <DropdownListItem
+      label={locale.name}
+      key={_.uniqueId('locale-selector')}
+      onClick={() => handleClickCaption(locale.locale, selected)}
+      iconRight={selected == locale.locale ? 'check' : null}
+      className={selected == locale.locale ? styles.selectedLocale : ''}
+    />
+    ))
+  );
+};
+
+const CaptionsButton = ({ intl, isActive, handleOnClick, ownedLocales, selectedLocale }) => (
+  <div className={styles.offsetBottom}>
+    <Button
+      className={cx(isActive || styles.btn)}
+      icon="closed_caption"
+      label={intl.formatMessage(isActive ? intlMessages.stop : intlMessages.start)}
+      color={isActive ? 'primary' : 'default'}
+      ghost={!isActive}
+      hideLabel
+      circle
+      size="lg"
+      onClick={handleOnClick}
+      id={isActive ? 'stop-captions-button' : 'start-captions-button'}
+    />
+    {isActive &&
+      <Dropdown>
+        <DropdownTrigger tabIndex={0}>
+        <ButtonEmoji
+          emoji="device_list_selector"
+          hideLabel
+          label={intl.formatMessage(intlMessages.changeCaption)}
+        />
+        </DropdownTrigger>
+        <DropdownContent placement="top left">
+          <DropdownList>
+            {getAvailableCaptions(ownedLocales, selectedLocale)}
+          </DropdownList>
+        </DropdownContent>
+      </Dropdown>
+    }
+  </div>
 );
 
 CaptionsButton.propTypes = propTypes;

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/captions/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/captions/component.jsx
@@ -5,7 +5,6 @@ import { defineMessages, injectIntl } from 'react-intl';
 import { styles } from '/imports/ui/components/actions-bar/styles';
 import Button from '/imports/ui/components/button/component';
 import ButtonEmoji from '/imports/ui/components/button/button-emoji/ButtonEmoji';
-import CaptionsService from '/imports/ui/components/captions/service';
 import { Session } from 'meteor/session';
 import _ from 'lodash';
 import Dropdown from '/imports/ui/components/dropdown/component';

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/captions/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/captions/container.jsx
@@ -4,6 +4,9 @@ import { withModalMounter } from '/imports/ui/components/modal/service';
 import CaptionsService from '/imports/ui/components/captions/service';
 import CaptionsReaderMenuContainer from '/imports/ui/components/actions-bar/captions/reader-menu/container';
 import CaptionsButton from './component';
+import Storage from '/imports/ui/services/storage/session';
+
+const CAPTION_LOCALE = "captionLocale";
 
 const CaptionsButtonContainer = (props) => <CaptionsButton {...props} />;
 
@@ -12,4 +15,6 @@ export default withModalMounter(withTracker(({ mountModal }) => ({
   handleOnClick: () => (CaptionsService.isCaptionsActive()
     ? CaptionsService.deactivateCaptions()
     : mountModal(<CaptionsReaderMenuContainer />)),
+  ownedLocales: CaptionsService.getOwnedLocales(),
+  selectedLocale: Storage.getItem(CAPTION_LOCALE),
 }))(CaptionsButtonContainer));

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/captions/reader-menu/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/captions/reader-menu/component.jsx
@@ -254,10 +254,10 @@ class ReaderMenu extends PureComponent {
                   {intl.formatMessage(intlMessages.ariaSelectLang)}
                 </div>
                 <select
-                  value={Storage.getItem(CAPTION_LOCALE)}
                   aria-label={intl.formatMessage(intlMessages.ariaSelectLang)}
                   className={styles.select}
                   onChange={this.handleLocaleChange}
+                  defaultValue={Storage.getItem(CAPTION_LOCALE)}
                   lang={locale}
                 >
                   <option

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/captions/reader-menu/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/captions/reader-menu/component.jsx
@@ -6,12 +6,14 @@ import { GithubPicker } from 'react-color';
 import { defineMessages, injectIntl } from 'react-intl';
 import { withModalMounter } from '/imports/ui/components/modal/service';
 import { styles } from './styles.scss';
+import Storage from '/imports/ui/services/storage/session';
 
 const DEFAULT_VALUE = 'select';
 const DEFAULT_KEY = -1;
 const DEFAULT_INDEX = 0;
 const FONT_FAMILIES = ['Arial', 'Calibri', 'Times New Roman', 'Sans-serif'];
 const FONT_SIZES = ['12px', '14px', '18px', '24px', '32px', '42px'];
+const CAPTION_LOCALE = 'captionLocale';
 
 // Not using hex values to force the githubPicker UI to display color names on hover
 const COLORS = [
@@ -114,8 +116,17 @@ class ReaderMenu extends PureComponent {
 
     const { ownedLocales } = this.props;
 
+    let initLocale;
+    if (Storage.getItem(CAPTION_LOCALE)) {
+      initLocale = Storage.getItem(CAPTION_LOCALE);
+    } else {
+      const locale = (ownedLocales && ownedLocales[0]) ? ownedLocales[0].locale : null;
+      Storage.setItem(CAPTION_LOCALE, locale);
+      initLocale = locale;
+    }
+
     this.state = {
-      locale: (ownedLocales && ownedLocales[0]) ? ownedLocales[0].locale : null,
+      locale: initLocale,
       backgroundColor,
       fontColor,
       fontFamily,
@@ -155,6 +166,7 @@ class ReaderMenu extends PureComponent {
   }
 
   handleLocaleChange(event) {
+    Storage.setItem(CAPTION_LOCALE, event.target.value);
     this.setState({ locale: event.target.value });
   }
 
@@ -242,6 +254,7 @@ class ReaderMenu extends PureComponent {
                   {intl.formatMessage(intlMessages.ariaSelectLang)}
                 </div>
                 <select
+                  value={Storage.getItem(CAPTION_LOCALE)}
                   aria-label={intl.formatMessage(intlMessages.ariaSelectLang)}
                   className={styles.select}
                   onChange={this.handleLocaleChange}

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/captions/reader-menu/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/captions/reader-menu/component.jsx
@@ -117,7 +117,7 @@ class ReaderMenu extends PureComponent {
     const { ownedLocales } = this.props;
 
     let initLocale;
-    if (Storage.getItem(CAPTION_LOCALE)) {
+    if (Storage.getItem(CAPTION_LOCALE) && ownedLocales.some ( locale => locale.locale == Storage.getItem(CAPTION_LOCALE)) ) {
       initLocale = Storage.getItem(CAPTION_LOCALE);
     } else {
       const locale = (ownedLocales && ownedLocales[0]) ? ownedLocales[0].locale : null;
@@ -166,7 +166,6 @@ class ReaderMenu extends PureComponent {
   }
 
   handleLocaleChange(event) {
-    Storage.setItem(CAPTION_LOCALE, event.target.value);
     this.setState({ locale: event.target.value });
   }
 
@@ -191,6 +190,7 @@ class ReaderMenu extends PureComponent {
       fontFamily,
       fontSize,
     };
+    Storage.setItem(CAPTION_LOCALE, locale);
     activateCaptions(locale, settings);
     closeModal();
   }
@@ -258,7 +258,6 @@ class ReaderMenu extends PureComponent {
                   aria-label={intl.formatMessage(intlMessages.ariaSelectLang)}
                   className={styles.select}
                   onChange={this.handleLocaleChange}
-                  defaultValue={defaultLocale}
                   lang={locale}
                 >
                   <option

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/styles.scss
@@ -175,3 +175,7 @@
     max-height: 100%;
   }
 }
+
+.selectedLocale {
+  font-weight: bold !important;
+}

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -362,6 +362,7 @@
     "app.actionsBar.camOffLabel": "Camera off",
     "app.actionsBar.raiseLabel": "Raise",
     "app.actionsBar.label": "Actions bar",
+    "app.actionsBar.changeCaption": "Switch caption locale",
     "app.actionsBar.actionsDropdown.restorePresentationLabel": "Restore presentation",
     "app.actionsBar.actionsDropdown.restorePresentationDesc": "Button to restore presentation after it has been minimized",
     "app.actionsBar.actionsDropdown.minimizePresentationLabel": "Minimize presentation",


### PR DESCRIPTION
### What does this PR do?

Enables a quick switching between locales of closed captions with the UI similar to the audio selector.
This is an allied PR with #???? and #???, but modification itself is independent.

### Closes Issue(s)

Closes #14325


### Motivation

When you use the closed caption function with more than one language, you may want to switch between the caption locales. With the current UI, however, you need to turn off and on the caption to do so. And the selection is not remembered, meaning that your previous choice goes back to the default locale every time.

### More

![153308215-f96f18f7-ec69-4c8f-a8c6-278a933de1a0](https://user-images.githubusercontent.com/45039819/153741287-e05f17da-51fd-46dd-93fc-b88aa9a6db93.gif)

