### PR TITLE
feat(closed caption) Automatic dictation translation #2 (server-side implementation of Google and DeepL)

### DIFF
--- a/bigbluebutton-html5/imports/api/captions/server/methods.js
+++ b/bigbluebutton-html5/imports/api/captions/server/methods.js
@@ -2,9 +2,11 @@ import { Meteor } from 'meteor/meteor';
 import takeOwnership from '/imports/api/captions/server/methods/takeOwnership';
 import appendText from '/imports/api/captions/server/methods/appendText';
 import getPadId from '/imports/api/captions/server/methods/getPadId';
+import toggleAutoTranslation from '/imports/api/captions/server/methods/toggleAutoTranslation';
 
 Meteor.methods({
   takeOwnership,
   appendText,
   getPadId,
+  toggleAutoTranslation,
 });

--- a/bigbluebutton-html5/imports/api/captions/server/methods/appendText.js
+++ b/bigbluebutton-html5/imports/api/captions/server/methods/appendText.js
@@ -5,38 +5,69 @@ import Captions from '/imports/api/captions';
 import { appendTextURL } from '/imports/api/common/server/etherpad';
 import { extractCredentials } from '/imports/api/common/server/helpers';
 
-export default function appendText(text, locale) {
+const CAPTIONS_CONFIG = Meteor.settings.public.captions;
+
+function sendToPad (padId, text) {
+  axios({
+    method: 'get',
+    url: appendTextURL(padId, text),
+    responseType: 'json',
+  }).then((response) => {
+    const { status } = response;
+    if (status !== 200) {
+      Logger.error(`Could not append captions for padId=${padId}`);
+    }
+  }).catch((error) => Logger.error(`Could not append captions for padId=${padId}: ${error}`));
+}
+
+function translateText (padId, index, textOri, src, dst) {
+  const url = CAPTIONS_CONFIG.googleTranslateUrl + '/exec?' +
+              'text=' + encodeURIComponent(textOri) + '&source=' + src + '&target=' + dst;
+
+  if (index === 0) {
+      sendToPad(padId, textOri);
+  } else {
+    axios({
+      method: 'get',
+      url,
+      responseType: 'json',
+    }).then((response) => {
+      const { code, text } = response.data;
+      if (code === 200) {
+        //sendToPad(padId, text.replace(/\n+$/,''));
+        sendToPad(padId, text);
+      } else {
+        Logger.error(`Could not get translation for ${textOri}`);
+      }
+    }).catch((error) => Logger.error(`Could not get translation for ${textOri}: ${error}`));
+
+  }
+}
+
+export default function appendText(text, locales) {
   try {
     const { meetingId, requesterUserId } = extractCredentials(this.userId);
 
     check(meetingId, String);
     check(requesterUserId, String);
     check(text, String);
-    check(locale, String);
+    check(locales, Array);
 
-    const captions = Captions.findOne({
-      meetingId,
-      locale,
-      ownerId: requesterUserId,
-    });
+    locales.forEach(function(locale, index) {
+      const captions = Captions.findOne({
+        meetingId,
+        locale,
+        ownerId: requesterUserId,
+      });
 
-    if (!captions) {
-      Logger.error(`Could not find captions' pad for meetingId=${meetingId} locale=${locale}`);
-      return;
-    }
-
-    const { padId } = captions;
-
-    axios({
-      method: 'get',
-      url: appendTextURL(padId, text),
-      responseType: 'json',
-    }).then((response) => {
-      const { status } = response;
-      if (status !== 200) {
-        Logger.error(`Could not append captions for padId=${padId}`);
+      if (!captions) {
+        Logger.error(`Could not find captions' pad for meetingId=${meetingId} locale=${locale}`);
+        return;
       }
-    }).catch((error) => Logger.error(`Could not append captions for padId=${padId}: ${error}`));
+
+      const { padId } = captions;
+      translateText(padId, index, text, locales[0], locale);
+    });
   } catch (err) {
     Logger.error(`Exception while invoking method appendText ${err.stack}`);
   }

--- a/bigbluebutton-html5/imports/api/captions/server/methods/appendText.js
+++ b/bigbluebutton-html5/imports/api/captions/server/methods/appendText.js
@@ -30,7 +30,8 @@ function translateText (padId, index, textOri, src, dst) {
             'text=' + encodeURIComponent(textOri) + '&source=' + src + '&target=' + dst;
     } else if (CAPTIONS_CONFIG.deeplTranslateUrl) {
       url = CAPTIONS_CONFIG.deeplTranslateUrl +
-            '&target_lang=' + dst + '&text=' + encodeURIComponent(textOri);
+            '&text=' + encodeURIComponent(textOri) + '&source_lang=' + src.toUpperCase() +
+            '&target_lang=' + dst.toUpperCase();
     } else {
       Logger.error('Could not get a translation service.');
       return;

--- a/bigbluebutton-html5/imports/api/captions/server/methods/appendText.js
+++ b/bigbluebutton-html5/imports/api/captions/server/methods/appendText.js
@@ -34,7 +34,6 @@ function translateText (padId, index, textOri, src, dst) {
     }).then((response) => {
       const { code, text } = response.data;
       if (code === 200) {
-        //sendToPad(padId, text.replace(/\n+$/,''));
         sendToPad(padId, text);
       } else {
         Logger.error(`Could not get translation for ${textOri}`);

--- a/bigbluebutton-html5/imports/api/captions/server/methods/toggleAutoTranslation.js
+++ b/bigbluebutton-html5/imports/api/captions/server/methods/toggleAutoTranslation.js
@@ -1,0 +1,20 @@
+import { check } from 'meteor/check';
+import Captions from '/imports/api/captions';
+import { extractCredentials } from '/imports/api/common/server/helpers';
+import Logger from '/imports/startup/server/logger';
+import setAutoTranslation from '/imports/api/captions/server/modifiers/setAutoTranslation';
+
+export default function toggleAutoTranslation(locale) {
+  try {
+    const { meetingId, requesterUserId } = extractCredentials(this.userId);
+
+    check(locale, String);
+    check(meetingId, String);
+    check(requesterUserId, String);
+
+    const caption = Captions.findOne({ meetingId, locale }, { fields: { autoTranslation:1 } });
+    setAutoTranslation(meetingId, locale, !caption.autoTranslation);
+  } catch (err) {
+    Logger.error(`Exception while invoking method toggleAutoTranslation ${err.stack}`);
+  }
+}

--- a/bigbluebutton-html5/imports/api/captions/server/modifiers/addCaption.js
+++ b/bigbluebutton-html5/imports/api/captions/server/modifiers/addCaption.js
@@ -23,6 +23,7 @@ export default function addCaption(meetingId, padId, locale, name) {
     data: '',
     revs: 0,
     length: 0,
+    autoTranslation: false,
   };
 
   try {

--- a/bigbluebutton-html5/imports/api/captions/server/modifiers/setAutoTranslation.js
+++ b/bigbluebutton-html5/imports/api/captions/server/modifiers/setAutoTranslation.js
@@ -1,0 +1,31 @@
+import Captions from '/imports/api/captions';
+import Logger from '/imports/startup/server/logger';
+import { check } from 'meteor/check';
+
+export default function setAutoTranslation(meetingId, locale, autoTranslation) {
+  check(meetingId, String);
+  check(locale, String);
+  check(autoTranslation, Boolean);
+
+  const selector = {
+    meetingId,
+    locale,
+  };
+
+  const modifier = {
+    $set: {
+      autoTranslation,
+    }
+  };
+
+  try {
+    const numberAffected = Captions.update(selector, modifier);
+//console.log("MODIFIER", Captions.findOne({locale, meetingId}));
+
+    if (numberAffected) {
+      Logger.verbose('Captions: updated pad autoTranslation', { locale });
+    }
+  } catch (err) {
+    Logger.error(`Updating captions pad autoTranslation: ${err}`);
+  }
+}

--- a/bigbluebutton-html5/imports/api/captions/server/modifiers/setAutoTranslation.js
+++ b/bigbluebutton-html5/imports/api/captions/server/modifiers/setAutoTranslation.js
@@ -20,7 +20,6 @@ export default function setAutoTranslation(meetingId, locale, autoTranslation) {
 
   try {
     const numberAffected = Captions.update(selector, modifier);
-//console.log("MODIFIER", Captions.findOne({locale, meetingId}));
 
     if (numberAffected) {
       Logger.verbose('Captions: updated pad autoTranslation', { locale });

--- a/bigbluebutton-html5/imports/ui/components/captions/pad/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/captions/pad/component.jsx
@@ -9,6 +9,8 @@ import CaptionsService from '/imports/ui/components/captions/service';
 import { notify } from '/imports/ui/services/notification';
 import { styles } from './styles';
 import { PANELS, ACTIONS } from '../../layout/enums';
+import Toggle from '/imports/ui/components/switch/component';
+import cx from 'classnames';
 import _ from 'lodash';
 
 const intlMessages = defineMessages({
@@ -27,6 +29,14 @@ const intlMessages = defineMessages({
   takeOwnershipTooltip: {
     id: 'app.captions.pad.ownershipTooltip',
     description: 'Text for button for taking ownership of closed captions pad',
+  },
+  autoTranslation: {
+    id: 'app.captions.pad.autoTranslation',
+    description: 'Label for auto translation of closed captions pad',
+  },
+  autoTranslationDesc: {
+    id: 'app.captions.pad.autoTranslationDesc',
+    description: 'Descriotion for auto translation of closed captions pad',
   },
   interimResult: {
     id: 'app.captions.pad.interimResult',
@@ -91,6 +101,7 @@ class Pad extends PureComponent {
 
     this.toggleListen = _.debounce(this.toggleListen.bind(this), DEBOUNCE_TIMEOUT, DEBOUNCE_OPTIONS);
     this.handleListen = this.handleListen.bind(this);
+    this.handleToggleAutoTranslation = this.handleToggleAutoTranslation.bind(this);
 
     if (this.recognition) {
       this.recognition.addEventListener('end', () => {
@@ -219,6 +230,15 @@ class Pad extends PureComponent {
     }, this.handleListen);
   }
 
+  handleToggleAutoTranslation() {
+    const {
+      locale,
+      toggleAutoTranslation,
+    } = this.props;
+    
+    toggleAutoTranslation(locale);
+  }
+
   stopListen() {
     this.setState({ listening: false });
   }
@@ -231,6 +251,8 @@ class Pad extends PureComponent {
       name,
       layoutContextDispatch,
       isResizing,
+      isAutoTranslated,
+      ownedLocales,
     } = this.props;
 
     const {
@@ -290,6 +312,33 @@ class Pad extends PureComponent {
               />
             ) : null}
         </header>
+        {CaptionsService.canIDictateThisPad(ownerId) && CaptionsService.isAutoTranslationEnabled() && ownedLocales.length > 1 && !listening
+          ? (
+          <div className={styles.form}>
+            <div className={styles.row}>
+              <div className={styles.col} aria-hidden="true">
+                <div className={styles.formElement}>
+                  <label className={styles.label}>
+                    {intl.formatMessage(intlMessages.autoTranslationDesc)}
+                  </label>
+                </div>
+              </div>
+              <div className={styles.col}>
+                <div className={cx(styles.formElement, styles.pullContentRight)}>
+                  <Toggle
+                    icons={false}
+                    disabled={listening}
+                    checked={isAutoTranslated}
+                    onChange={this.handleToggleAutoTranslation}
+                    ariaLabelledBy="autoTransToggle"
+                    ariaLabel={intl.formatMessage(intlMessages.autoTranslation)}
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+          )
+          : null}
         {listening ? (
           <div>
             <span className={styles.interimTitle}>

--- a/bigbluebutton-html5/imports/ui/components/captions/pad/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/captions/pad/container.jsx
@@ -52,5 +52,8 @@ export default withTracker(() => {
     ownerId,
     currentUserId: Auth.userID,
     amIModerator: CaptionsService.amIModerator(),
+    isAutoTranslated: CaptionsService.isAutoTranslated(locale),
+    toggleAutoTranslation: CaptionsService.toggleAutoTranslation,
+    ownedLocales: CaptionsService.getOwnedLocales(),
   };
 })(PadContainer);

--- a/bigbluebutton-html5/imports/ui/components/captions/pad/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/captions/pad/styles.scss
@@ -107,6 +107,55 @@
   }
 }
 
+.pullContentRight {
+  display: flex;
+  justify-content: flex-end;
+  flex-flow: row;
+  align-items: center;
+}
+
+.formElement {
+  position: relative;
+  display: flex;
+  flex-flow: column;
+  flex-grow: 1;
+}
+
+.label {
+  color: var(--color-gray-label);
+  font-size: 0.9rem;
+  margin-bottom: 0.5rem;
+}
+
+.form {
+  display: flex;
+  flex-flow: column;
+}
+
+.row {
+  display: flex;
+  flex-flow: row;
+  flex-grow: 1;
+  justify-content: space-between;
+  margin-bottom: 0.7rem;
+}
+
+.col {
+  display: flex;
+  flex-grow: 1;
+  flex-basis: 0;
+
+  &:last-child {
+    padding-right: 0;
+    padding-left: 1rem;
+
+    [dir="rtl"] & {
+      padding-right: 0.1rem;
+      padding-left: 0;
+    }
+  }
+}
+
 iframe {
   display: flex;
   flex-flow: column;

--- a/bigbluebutton-html5/imports/ui/components/captions/service.js
+++ b/bigbluebutton-html5/imports/ui/components/captions/service.js
@@ -105,7 +105,7 @@ const takeOwnership = (locale) => {
 const appendText = (text, locale) => {
   if (typeof text !== 'string' || text.length === 0) return;
 
-  const formattedText = `${text.trim().replace(/^\w/, (c) => c?.toUpperCase()).replace(/\n+$/, '')}\n`;
+  const formattedText = `${text.trim().replace(/^\w/, (c) => c?.toUpperCase())}\n`;
   const localedAutoTranslated = getLocalesAutoTranslated();
 
   let locales = [locale];

--- a/bigbluebutton-html5/imports/ui/components/captions/service.js
+++ b/bigbluebutton-html5/imports/ui/components/captions/service.js
@@ -39,6 +39,32 @@ const getCaptionsData = () => {
   return { locale, revs, data };
 };
 
+const getLocalesAutoTranslated = () => {
+  const { meetingID } = Auth;
+  const locales = [];
+  Captions.find({ meetingId: meetingID, autoTranslation: true },
+    { fields: { ownerId: 1, locale: 1, name: 1 } })
+    .forEach((caption) => {
+      if (caption.ownerId !== '') {
+        locales.push({
+          locale: caption.locale,
+          name: caption.name,
+        });
+      }
+    });
+  return locales;
+};
+
+const isAutoTranslated = (locale) => {
+  const { meetingID } = Auth;
+  const loc = Captions.findOne({ meetingId: meetingID, locale });
+  return loc.autoTranslation;
+};
+
+const toggleAutoTranslation = (locale) => {
+  makeCall('toggleAutoTranslation', locale);
+};
+
 const getAvailableLocales = () => {
   const { meetingID } = Auth;
   const locales = [];
@@ -79,8 +105,17 @@ const takeOwnership = (locale) => {
 const appendText = (text, locale) => {
   if (typeof text !== 'string' || text.length === 0) return;
 
-  const formattedText = `${text.trim().replace(/^\w/, (c) => c?.toUpperCase())}\n\n`;
-  makeCall('appendText', formattedText, locale);
+  const formattedText = `${text.trim().replace(/^\w/, (c) => c?.toUpperCase()).replace(/\n+$/, '')}\n`;
+  const localedAutoTranslated = getLocalesAutoTranslated();
+
+  let locales = [locale];
+  for (let localeTrans of localedAutoTranslated) {
+    if (localeTrans.locale != locale) {
+      locales.push(localeTrans.locale);
+    }
+  }
+
+  makeCall('appendText', formattedText, locales);
 };
 
 const canIOwnThisPad = (ownerId) => {
@@ -99,6 +134,10 @@ const canIDictateThisPad = (ownerId) => {
   const SpeechRecognitionAPI = getSpeechRecognitionAPI();
   if (!SpeechRecognitionAPI) return false;
   return ownerId === userID;
+};
+
+const isAutoTranslationEnabled = () => {
+  return CAPTIONS_CONFIG.enableAutomaticTranslation;
 };
 
 const setActiveCaptions = (locale) => {
@@ -196,4 +235,7 @@ export default {
   formatCaptionsText,
   amIModerator,
   initSpeechRecognition,
+  isAutoTranslated,
+  toggleAutoTranslation,
+  isAutoTranslationEnabled,
 };

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -442,6 +442,8 @@ public:
   captions:
     enabled: true
     enableDictation: false
+    enableAutomaticTranslation: false
+    googleTranslateUrl: https://script.google.com/macros/s/YOUR_ID
     backgroundColor: '#000000'
     fontColor: '#FFFFFF'
     fontFamily: Calibri

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -444,6 +444,7 @@ public:
     enableDictation: false
     enableAutomaticTranslation: false
     googleTranslateUrl: https://script.google.com/macros/s/YOUR_ID
+    deeplTranslateUrl: https://api-free.deepl.com/v2/translate?auth_key=YOUR_KEY
     backgroundColor: '#000000'
     fontColor: '#FFFFFF'
     fontFamily: Calibri

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -46,6 +46,8 @@
     "app.captions.pad.tip": "Press Esc to focus editor toolbar",
     "app.captions.pad.ownership": "Take over",
     "app.captions.pad.ownershipTooltip": "You will be assigned as the owner of {0} captions",
+    "app.captions.pad.autoTranslation": "Toggle automatic translation",
+    "app.captions.pad.autoTranslationDesc": "AI translation from the dictated language",
     "app.captions.pad.interimResult": "Interim results",
     "app.captions.pad.dictationStart": "Start dictation",
     "app.captions.pad.dictationStop": "Stop dictation",


### PR DESCRIPTION
### What does this PR do?

Enables a real-time Google / DeepL translation of dictation, by the use of their APIs. This is an improved version of #13295, which does the translation on the client side, but this PR does it on the server side. So the overall traffic will be reduced. Also, the deepL translation is newly supported in this PR. 

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #


### Motivation

It would be fantastic if the spoken language in BBB is automatically translated and shown as closed captions to any language you would like. Google Translation and DeepL seems to provide a good quality of services for such purpose.

The previous PR #13295 was experimentally submitted for the same purpose, but there were two problems: 1, the implementation was very complex and 2, every viewer had to access to the translation service so the service was very flexible (the moderator did not need to prepare anything; just the viewer toggled the translation), but instead the overall traffic increased (a bit). This PR has been implemented in a very simple code and the translation is done on the server side, so the overall traffic increases only by the number of locales to be provided, but not by the number of viewers. 

### More

To enable this function, you have to first turn it on in the configuration file of BBB-html5. 

 &nbsp; &nbsp;captions:
 &nbsp; &nbsp; &nbsp; &nbsp;enableAutomaticTranslation: false
 &nbsp; &nbsp; &nbsp; &nbsp;googleTranslateUrl: https://script.google.com/macros/s/YOUR_ID
 &nbsp; &nbsp; &nbsp; &nbsp;deeplTranslateUrl: https://api-free.deepl.com/v2/translate?auth_key=YOUR_KEY

If you set both Google API and DeepL API, Google API has the priority. Note that the locales provided in DeepL is much less than Google Translation, and DeepL translation is charged in the pro account and the service limited for the free account.

For preparing the API for Google Translation please refer to #13295.
For preparing the API for DeepL, you have to create an account (free or pro) to obtain a key code for API (see https://www.deepl.com/pro-api?cta=header-pro-api).

To use it, the moderator starts the closed captions for the spoken language and translated languages (as many as you want). Then you set on the "AI assisted translation for the dictated language" in the caption pad (you don't need to do so for the spoken language). Then turn the dictation on in the pad for the spoken language and speak. The viewers subscribe the language that (s)he likes from the CC button on the action bar.

With the allied PR??? you can navigate the provided locales much easily. 

With the allied PR??? the recording works also for all the translated captions.

### Issues

There were at least two problems in the previous PR #13295, namely, no "default" translation and broken written captions. Both have been solved anyhow in this PR.

Privacy problem is inevitable. Every spoken sentence will be sent to the server of commercial companies. I believe they are rational enough but there is no guarantee. As far as I know, there are no other translation services that can compete with the two services implemented here. But if you know a good one with less privacy issue, putting it in this PR would not be very difficult. 

![after](https://user-images.githubusercontent.com/45039819/153740451-6cd77308-06d6-4103-b1fa-df9e57b7135d.gif)

