### PR TITLE
fix(akka-apps) Don't clear the captions' owner IDs for a proper recording

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/CaptionModel.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/CaptionModel.scala
@@ -23,15 +23,6 @@ class CaptionModel {
   def updateTranscriptOwner(locale: String, localeCode: String, ownerId: String): Map[String, TranscriptVO] = {
     var updatedTranscripts = new HashMap[String, TranscriptVO]
 
-    // clear owner from previous locale
-    if (ownerId.length > 0) {
-      findTranscriptByOwnerId(ownerId).foreach(t => {
-        val oldTranscript = t._2.copy(ownerId = "")
-
-        transcripts += t._1 -> oldTranscript
-        updatedTranscripts += t._1 -> oldTranscript
-      })
-    }
     // change the owner if it does exist
     if (transcripts contains locale) {
       val newTranscript = transcripts(locale).copy(ownerId = ownerId)


### PR DESCRIPTION
### What does this PR do?

Keep the owner ID of the closed captions when a new locale is started  by the same moderator.

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #14353

### Motivation

To fix a bug reported in #14353. In short, the recording function does not work properly when multiple locales are used for the closed captions by a single moderator.

### More

This is one of the allied PRs with #??? and #???, but modification itself is independent of others.
