### PR TITLE
Dev3.0.14 suppress notification

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/app/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/component.jsx
@@ -127,12 +127,14 @@ class App extends Component {
     };
 
     this.timeOffsetInterval = null;
+    this.isPopupOnPreparation = false;
 
     this.setPresentationFitToWidth = this.setPresentationFitToWidth.bind(this);
     this.setAudioModalIsOpen = this.setAudioModalIsOpen.bind(this);
     this.setVideoPreviewModalIsOpen = this.setVideoPreviewModalIsOpen.bind(this);
     this.customPollShortcutHandler = this.customPollShortcutHandler.bind(this);
     this.logJoin = this.logJoin.bind(this);
+    this.handlePopupPreparing = this.handlePopupPreparing.bind(this);
   }
 
   componentDidMount() {
@@ -275,6 +277,10 @@ class App extends Component {
     }
   }
 
+  handlePopupPreparing(b) {
+    this.isPopupOnPreparation = b;
+  }
+
   renderDarkMode() {
     const { darkTheme } = this.props;
 
@@ -373,7 +379,7 @@ class App extends Component {
           <ActivityCheckContainer />
           <ScreenReaderAlertContainer />
           <BannerBarContainer />
-          <NotificationsBarContainer />
+          <NotificationsBarContainer isPopupOnPreparation={this.isPopupOnPreparation} />
           <SidebarNavigationContainer />
           <SidebarContentContainer isSharedNotesPinned={isSharedNotesPinned} />
           <NavBarContainer main="new" />
@@ -396,6 +402,7 @@ class App extends Component {
                 popupWindow={popupWindow}
                 isPresentationDetached={isPresentationDetached}
                 toggleDetachPresentation={toggleDetachPresentation}
+                onPopupPreparing={this.handlePopupPreparing}
               />
             )
             : null

--- a/bigbluebutton-html5/imports/ui/components/notifications-bar/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/notifications-bar/container.jsx
@@ -40,7 +40,7 @@ const intlMessages = defineMessages({
 const STATUS_CRITICAL = 'critical';
 const COLOR_PRIMARY = 'primary';
 
-const NotificationsBarContainer = () => {
+const NotificationsBarContainer = ({ isPopupOnPreparation }) => {
   const intl = useIntl();
 
   const { hasNotification } = layoutSelectInput((i) => i.notificationsBar);
@@ -60,6 +60,13 @@ const NotificationsBarContainer = () => {
 
   const errorMessage = useMemo(() => {
     const isCritical = rttStatus === STATUS_CRITICAL;
+
+    // When subscriptionFailed error comes when the popup is under preparation,
+    //  return null and clear the stacked subscriptionFaied error.
+    if (isPopupOnPreparation && subscriptionFailed) {
+      connectionStatus.getSubscriptionFailedVar()(false);
+      return null;
+    }
 
     if (!connected) {
       const code = isCritical ? 3002 : 3001;
@@ -137,6 +144,7 @@ const NotificationsBarContainer = () => {
     rttStatus,
     subscriptionFailed,
     intl,
+    isPopupOnPreparation,
   ]);
 
   const meetingMessage = useMemo(() => {

--- a/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
@@ -501,6 +501,7 @@ class Presentation extends PureComponent {
 
       toggleDetachPresentation(popup);
       popup.addEventListener('beforeunload', () => {
+        onPopupPreparing?.(false); // Only when the popup is closed very quickly, but may not be necessary..
         toggleDetachPresentation(null);
       });
       

--- a/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
@@ -380,6 +380,7 @@ class Presentation extends PureComponent {
       isPresentationDetached,
       popupWindow,
       toggleDetachPresentation,
+      onPopupPreparing,
     } = this.props;
 
     if (!isPresentationDetached) {
@@ -391,6 +392,10 @@ class Presentation extends PureComponent {
       popup.document.title = 'BigBlueButton Portal Window';
       const container = popup.document.createElement('div');
       popup.document.body.appendChild(container);
+
+      // popup window is still in preparation, so some graphql transaction drops,
+      //  which then will show the notification bar. We want to surpress it.
+      onPopupPreparing?.(true);
 
       // headの中身をコピー
       const headElements = document.head.cloneNode(true).childNodes;
@@ -516,6 +521,19 @@ class Presentation extends PureComponent {
         }
         // Then normal fullscreen change (by button or ESC)
         this.onFullscreenChange();
+
+        // when the canvas of tldraw is drawn on the popup,
+        //  we will set false to isPopupOnPreparation.
+        // Then the notification bar with 3006 error becomes accepted again.
+        const observer = new MutationObserver((mutations, obs) => {
+          const tlCanvas = popup.document.querySelector('.tl-canvas');
+          if (tlCanvas) {
+            onPopupPreparing?.(false);
+            obs.disconnect();
+          }
+        });
+        observer.observe(popup.document.body, { childList: true, subtree: true });
+        
       });
     } else {
       // to explicitely exit fullsreen; we do not need setState "isFullscreen: false".
@@ -524,6 +542,7 @@ class Presentation extends PureComponent {
         type: ACTIONS.SET_FULLSCREEN_ELEMENT,
         value: { element: '', group: '' },
       });
+      // Basically the app does not reach here...
       popupWindow?.close();
       toggleDetachPresentation(null);
     }


### PR DESCRIPTION
To surpress the error 3006 appearing on the notification bar.
This happens because some graphql transactions are dropped before the popup is fully drawn. 
We judge the timing by the emergence of tl-canvas element.