### PR TITLE
Dev3.0.14 add jpn font simplified

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
@@ -445,7 +445,7 @@ class Presentation extends PureComponent {
       //  this fix the inconsistency of var(--tl-font-draw) between popup and main window.
       const fonts = [
         { name: 'tldraw_draw', url: '/html5client/fonts/tldraw/Shantell_Sans-Tldrawish.woff2' },
-        { name: 'KosugiMaruSubset', url: '/html5client/fonts/KosugiMaru/KosugiMaru-Regular.woff2' },
+        //{ name: 'KosugiMaruSubset', url: '/html5client/fonts/KosugiMaru/KosugiMaru-Regular.woff2' },
         { name: 'tldraw_sans', url: '/html5client/fonts/tldraw/IBMPlexSans-Medium.woff2' },
         { name: 'tldraw_serif', url: '/html5client/fonts/tldraw/IBMPlexSerif-Medium.woff2' },
         { name: 'tldraw_mono', url: '/html5client/fonts/tldraw/IBMPlexMono-Medium.woff2' },
@@ -454,13 +454,13 @@ class Presentation extends PureComponent {
         const font = new FontFace(name, `url(${window.location.origin}${url})`);
         font.load().then(loaded => popup.document.fonts.add(loaded));
       });
-      const drawFontstyle = popup.document.createElement('style');
-      drawFontstyle.textContent = `
-        .tl-text-shape__wrapper[data-font='draw'] {
-          font-family: 'tldraw_draw', 'KosugiMaruSubset', sans-serif;
-        }
-      `;
-      popup.document.head.appendChild(drawFontstyle);
+      //const drawFontstyle = popup.document.createElement('style');
+      //drawFontstyle.textContent = `
+      //  .tl-text-shape__wrapper[data-font='draw'] {
+      //    font-family: 'tldraw_draw', 'KosugiMaruSubset', sans-serif;
+      // }
+      //`;
+      //popup.document.head.appendChild(drawFontstyle);
 
       // Remove cursor style from the class tl-canvas,
       //  otherwise cursor stays the same when pencil, text, line, note

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -2138,20 +2138,21 @@ const Whiteboard = React.memo((props) => {
   // To use Kosugi-Maru fonts also in the main window, as all the viewers do.
   // To use the font, you need to install the font under public/fonts/KosugiMaru and
   //  add sentences at public/stylesheets/fonts.css as done together in this PR.
-  React.useEffect(() => {
-    const kosugi = new FontFace(
-      'tldraw_draw',
-      `url(${window.location.origin}/html5client/fonts/KosugiMaru/KosugiMaru-Regular.woff2)`,
-      { weight: '400', style: 'normal' }
-    );
-    kosugi.load()
-      .then((loaded) => {
-        document.fonts.add(loaded);
-      })
-      .catch((err) => {
-        console.error('Failed to load KosugiMaru font:', err);
-      });
-  }, []);
+  //   -> moved to styles.css
+  //React.useEffect(() => {
+  //  const kosugi = new FontFace(
+  //    'tldraw_draw',
+  //    `url(${window.location.origin}/html5client/fonts/KosugiMaru/KosugiMaru-Regular.woff2)`,
+  //    { weight: '400', style: 'normal' }
+  //  );
+  //  kosugi.load()
+  //    .then((loaded) => {
+  //      document.fonts.add(loaded);
+  //    })
+  //    .catch((err) => {
+  //      console.error('Failed to load KosugiMaru font:', err);
+  //    });
+  //, []);
 
   React.useEffect(() => {
     setTldrawIsMounting(true);
@@ -2306,5 +2307,6 @@ Whiteboard.propTypes = {
   isInfiniteWhiteboard: PropTypes.bool,
   whiteboardWriters: PropTypes.arrayOf(PropTypes.shape).isRequired,
 };
+
 
 

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/styles.js
@@ -168,6 +168,10 @@ const TldrawV2GlobalStyle = createGlobalStyle`
     font-family: 'Arial', sans-serif !important;
   }
 
+  .tl-text-shape__wrapper[data-font='draw'] {
+    font-family: 'tldraw_draw', 'KosugiMaruSubset', sans-serif;
+  }
+
   [data-side="bottom"][data-align="end"][data-state="open"][role="dialog"] {
     right: 3.5rem !important;
     bottom: 9.5rem !important;


### PR DESCRIPTION
The implementation is now much more simplified.
KosugiMaru font is installed in the main window, only supplementing the Japanese glyphs, leaving the funny tldraw fonts as they are.
Then we only need to inject Shantell_Sans-Tldrawish.woff2, IBMPlexSans-Medium.woff2, IBMPlexSerif-Medium.woff2, and IBMPlexMono-Medium.woff2 on the popup. KosugiMaru is already supplemented to the draw font in the main window and all copied to the popup.