### PR TITLE
Fix: chat scrolls even with popped up presentation

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/component.tsx
@@ -40,6 +40,7 @@ import { ChatLoading } from '../component';
 import Storage from '/imports/ui/services/storage/in-memory';
 import browserInfo from '/imports/utils/browserInfo';
 import deviceInfo from '/imports/utils/deviceInfo';
+import { originalHTMLElement } from '/imports/utils/HTMLElementBackup';
 
 const PAGE_SIZE = 50;
 const CLEANUP_TIMEOUT = 3000;
@@ -71,7 +72,7 @@ interface ChatListProps {
 }
 
 const isElement = (el: unknown): el is HTMLElement => {
-  return el instanceof HTMLElement;
+  return el instanceof originalHTMLElement;
 };
 
 const isMap = (map: unknown): map is Map<number, string> => {

--- a/bigbluebutton-html5/imports/utils/HTMLElementBackup.ts
+++ b/bigbluebutton-html5/imports/utils/HTMLElementBackup.ts
@@ -1,0 +1,1 @@
+export const originalHTMLElement: typeof HTMLElement = window.HTMLElement;


### PR DESCRIPTION
The chat window did not scroll properly when the presentation is popped up. It's because window.HTMLElement is globally replaced by popup.HTMLWindow for fixing the problem that tldraw did not allow expand/shrink/rotate the drawings in the popup.
Many of other BBB components using HTMLElement had not been affected from this change, but the chat scrolling had been affected. There may be other components still affected.
