### PR TITLE
Backup original rAF/cAF to avoid the bad effects from the globally replaced popup.rAF/cAF

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/component.tsx
@@ -41,6 +41,7 @@ import Storage from '/imports/ui/services/storage/in-memory';
 import browserInfo from '/imports/utils/browserInfo';
 import deviceInfo from '/imports/utils/deviceInfo';
 import { originalHTMLElement } from '/imports/utils/HTMLElementBackup';
+import { originalRAF, originalCAF } from '/imports/utils/animationFrameBackup';
 
 const PAGE_SIZE = 50;
 const CLEANUP_TIMEOUT = 3000;
@@ -404,7 +405,7 @@ const ChatMessageList: React.FC<ChatListProps> = ({
       const value = (timestamp - initialTimestamp) / 300;
       if (value <= 1) {
         container.scrollTop = initialPosition + (value * scrollPositionDiff);
-        requestAnimationFrame(animateScrollPosition);
+        originalRAF(animateScrollPosition);
       } else {
         container.scrollTop = container.scrollHeight - container.offsetHeight;
         setIsScrollingDisabled(false);
@@ -421,10 +422,10 @@ const ChatMessageList: React.FC<ChatListProps> = ({
       initialTimestamp = timestamp;
       initialPosition = scrollTop;
       scrollPositionDiff = scrollHeight - offsetHeight - scrollTop;
-      requestAnimationFrame(animateScrollPosition);
+      originalRAF(animateScrollPosition);
     };
 
-    requestAnimationFrame(startScrollAnimation);
+    originalRAF(startScrollAnimation);
   }, []);
 
   const renderUnreadNotification = useMemo(() => {
@@ -538,7 +539,7 @@ const ChatMessageList: React.FC<ChatListProps> = ({
     },
   ) => {
     if (currentFrame < stabilityFrames) {
-      const frameId = requestAnimationFrame(() => {
+      const frameId = originalRAF(() => {
         pollScrollEndEvent(setFrameId, onScrollEnd, {
           stabilityFrames,
           currentFrame: currentFrame + 1,
@@ -553,10 +554,10 @@ const ChatMessageList: React.FC<ChatListProps> = ({
 
   const startScrollEndEventPolling = useCallback((onScrollEnd: () => void) => {
     if (scrollEndFrameRef.current != null) {
-      cancelAnimationFrame(scrollEndFrameRef.current);
+      originalCAF(scrollEndFrameRef.current);
       scrollEndFrameRef.current = undefined;
     }
-    scrollEndFrameRef.current = requestAnimationFrame(() => {
+    scrollEndFrameRef.current = originalRAF(() => {
       pollScrollEndEvent((frameId) => {
         scrollEndFrameRef.current = frameId;
       }, onScrollEnd);
@@ -609,7 +610,7 @@ const ChatMessageList: React.FC<ChatListProps> = ({
       clearInterval(scrollActivityCheckInterval.current);
     }
     if (scrollEndFrameRef.current) {
-      cancelAnimationFrame(scrollEndFrameRef.current);
+      originalCAF(scrollEndFrameRef.current);
     }
   }, []);
 

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
@@ -47,6 +47,7 @@ import { EmojiPicker, EmojiPickerWrapper } from './message-toolbar/styles';
 import { isMobile } from '/imports/utils/deviceInfo';
 import { layoutSelect } from '/imports/ui/components/layout/context';
 import { Layout } from '/imports/ui/components/layout/layoutTypes';
+import { originalRAF, originalCAF } from '/imports/utils/animationFrameBackup';
 
 interface ChatMessageProps {
   message: Message;
@@ -228,7 +229,7 @@ const ChatMessage = React.forwardRef<ChatMessageRef, ChatMessageProps>(({
   useImperativeHandle(ref, () => ({
     requestFocus() {
       setTimeout(() => {
-        requestAnimationFrame(startScrollAnimation);
+        originalRAF(startScrollAnimation);
       }, 0);
     },
     sequence: message.messageSequence,
@@ -236,20 +237,20 @@ const ChatMessage = React.forwardRef<ChatMessageRef, ChatMessageProps>(({
 
   const startScrollAnimation = (timestamp: number) => {
     if ((containerRef.current?.offsetTop || 0) > (scrollRef.current?.scrollTop || 0)) {
-      requestAnimationFrame(startBackgroundAnimation);
+      originalRAF(startBackgroundAnimation);
       return;
     }
     animationInitialScrollPosition.current = scrollRef.current?.scrollTop || 0;
     animationScrollPositionDiff.current = (scrollRef.current?.scrollTop || 0)
       - ((containerRef.current?.offsetTop || 0) - ((scrollRef.current?.offsetHeight || 0) / 2));
     animationInitialTimestamp.current = timestamp;
-    requestAnimationFrame(animateScrollPosition);
+    originalRAF(animateScrollPosition);
   };
 
   const startBackgroundAnimation = (timestamp: number) => {
     animationInitialTimestamp.current = timestamp;
     animationInitialBgColor.current = containerRef.current?.style.backgroundColor ?? '';
-    requestAnimationFrame(animateBackgroundColor);
+    originalRAF(animateBackgroundColor);
   };
 
   const animateScrollPosition = (timestamp: number) => {
@@ -261,10 +262,10 @@ const ChatMessage = React.forwardRef<ChatMessageRef, ChatMessageProps>(({
     if (!scrollContainer || !messageContainer) return;
     if (value <= 1) {
       scrollContainer.scrollTop = initialPosition - (value * diff);
-      requestAnimationFrame(animateScrollPosition);
+      originalRAF(animateScrollPosition);
     } else {
       scrollContainer.scrollTop = initialPosition - diff;
-      requestAnimationFrame(startBackgroundAnimation);
+      originalRAF(startBackgroundAnimation);
     }
   };
 
@@ -273,7 +274,7 @@ const ChatMessage = React.forwardRef<ChatMessageRef, ChatMessageProps>(({
     const value = (timestamp - animationInitialTimestamp.current) / ANIMATION_DURATION;
     if (value < 1) {
       messageContentRef.current.style.backgroundColor = `rgb(${colorBlueLighterChannel} / ${1 - value})`;
-      requestAnimationFrame(animateBackgroundColor);
+      originalRAF(animateBackgroundColor);
     } else {
       messageContentRef.current.style.backgroundColor = animationInitialBgColor.current;
     }
@@ -304,7 +305,7 @@ const ChatMessage = React.forwardRef<ChatMessageRef, ChatMessageProps>(({
     },
   ) => {
     if (currentFrame < stabilityFrames) {
-      const frameId = requestAnimationFrame(() => {
+      const frameId = originalRAF(() => {
         pollScrollEndEvent(setFrameId, {
           stabilityFrames,
           currentFrame: currentFrame + 1,
@@ -321,10 +322,10 @@ const ChatMessage = React.forwardRef<ChatMessageRef, ChatMessageProps>(({
 
   const startScrollEndEventPolling = useCallback(() => {
     if (scrollEndFrameRef.current != null) {
-      cancelAnimationFrame(scrollEndFrameRef.current);
+      originalCAF(scrollEndFrameRef.current);
       scrollEndFrameRef.current = undefined;
     }
-    scrollEndFrameRef.current = requestAnimationFrame(() => {
+    scrollEndFrameRef.current = originalRAF(() => {
       pollScrollEndEvent((frameId) => {
         scrollEndFrameRef.current = frameId;
       });
@@ -345,7 +346,7 @@ const ChatMessage = React.forwardRef<ChatMessageRef, ChatMessageProps>(({
     return () => {
       scrollRef?.current?.removeEventListener('scroll', callbackFunction);
       if (scrollEndFrameRef.current !== undefined) {
-        cancelAnimationFrame(scrollEndFrameRef.current);
+        originalCAF(scrollEndFrameRef.current);
         scrollEndFrameRef.current = undefined;
       }
     };

--- a/bigbluebutton-html5/imports/ui/components/emoji-rain/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/emoji-rain/component.jsx
@@ -2,6 +2,7 @@ import React, { useRef, useState, useEffect } from 'react';
 import { getSettingsSingletonInstance } from '/imports/ui/services/settings';
 import Service from './service';
 import logger from '/imports/startup/client/logger';
+//import { originalRAF } from '/imports/utils/animationFrameBackup';
 
 const EmojiRain = ({ reactions }) => {
   const Settings = getSettingsSingletonInstance();
@@ -57,6 +58,8 @@ const EmojiRain = ({ reactions }) => {
     }
 
     requestAnimationFrame(() => setTimeout(() => flyingEmojis.forEach((emoji) => {
+    // No effect observed (emoji rain works without using originalRAF). So removed.
+    //originalRAF(() => setTimeout(() => flyingEmojis.forEach((emoji) => {
       const { shapeElement, endPosition } = emoji;
       shapeElement.style.left = `${endPosition.x}px`;
       shapeElement.style.top = `${endPosition.y}px`;

--- a/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
@@ -20,6 +20,7 @@ import browserInfo from '/imports/utils/browserInfo';
 import { addAlert } from '../screenreader-alert/service';
 import { debounce } from '/imports/utils/debounce';
 import { throttle } from '/imports/utils/throttle';
+import { originalRAF, originalCAF } from '/imports/utils/animationFrameBackup';
 import LocatedErrorBoundary from '/imports/ui/components/common/error-boundary/located-error-boundary/component';
 import FallbackView from '/imports/ui/components/common/fallback-errors/fallback-view/component';
 import TooltipContainer from '/imports/ui/components/common/tooltip/container';
@@ -562,9 +563,21 @@ class Presentation extends PureComponent {
       //});
       //nullObserver.observe(observedTarget, { childList: true, subtree: true, characterData: true });
 
+      // Globally inject popup.requestAnimationFrame to requestAnimationFrame for internal usage of tldraw.
+      // These changes enable fullscreen of popup window in the main monitor.
+      if (popup.requestAnimationFrame) {
+        window.requestAnimationFrame = popup.requestAnimationFrame.bind(popup);
+      }
+      if (popup.cancelAnimationFrame) {
+        window.cancelAnimationFrame = popup.cancelAnimationFrame.bind(popup);
+      }
+
       toggleDetachPresentation(popup);
       popup.addEventListener('beforeunload', () => {
         onPopupPreparing?.(false); // Only when the popup is closed very quickly, but may not be necessary..
+        // Revert the injection of popup.rAF/cAF
+        window.requestAnimationFrame = originalRAF;
+        window.cancelAnimationFrame = originalCAF;
         toggleDetachPresentation(null);
       });
       

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/component.tsx
@@ -3,6 +3,7 @@ import { IntlShape, defineMessages, injectIntl } from 'react-intl';
 import { UpdatedDataForUserCameraDomElement } from 'bigbluebutton-html-plugin-sdk/dist/cjs/dom-element-manipulation/user-camera/types';
 import { throttle } from '/imports/utils/throttle';
 import { range } from '/imports/utils/array-utils';
+import { originalRAF } from '/imports/utils/animationFrameBackup';
 import Styled from './styles';
 import VideoListItemContainer from './video-list-item/container';
 import AutoplayOverlay from '/imports/ui/components/media/autoplay-overlay/component';
@@ -214,7 +215,8 @@ class VideoList extends Component<VideoListProps, VideoListState> {
 
   handleCanvasResize() {
     if (!this.ticking) {
-      window.requestAnimationFrame(() => {
+      // still unclear if this matters..
+      originalRAF(() => {
         this.ticking = false;
         this.setOptimalGrid();
       });

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -1986,6 +1986,7 @@ const Whiteboard = React.memo((props) => {
   // Thus some tldraw functions such as fullscreen and resize a drawing
   //  does not work on the popup window.
   // This actually modify a global variable, possibly causing other problems
+  //  -> Indeed. Now the original HTMLElement is backed up and used elsewhere.
   const originalHTMLElementRef = React.useRef<typeof HTMLElement | null>(window.HTMLElement);
   React.useEffect(() => {
     if (!isPresenter) return;
@@ -2306,6 +2307,7 @@ Whiteboard.propTypes = {
   isInfiniteWhiteboard: PropTypes.bool,
   whiteboardWriters: PropTypes.arrayOf(PropTypes.shape).isRequired,
 };
+
 
 
 

--- a/bigbluebutton-html5/imports/utils/animationFrameBackup.js
+++ b/bigbluebutton-html5/imports/utils/animationFrameBackup.js
@@ -1,0 +1,2 @@
+export const originalRAF = window.requestAnimationFrame.bind(window);
+export const originalCAF = window.cancelAnimationFrame.bind(window);


### PR DESCRIPTION
After the fix of zoom failure in the full-screened popup on the main monitor by hacking the window.requestAnimationFrame/window.cancelAnimationFrame, some of BBB's function including the 'catch the latest chat message' button is found broken. This PR fetches the original window.rAF/cAF and uses them for two BBB components (chat-graphql and video-provider/video-list). The emoji-rain component has left untouched (only leaving commented out codes) because no difference has been observed.
